### PR TITLE
Update to be able to use Pytest in TIR

### DIFF
--- a/tir/technologies/core/log.py
+++ b/tir/technologies/core/log.py
@@ -133,4 +133,7 @@ class Log:
         Returns a list of test cases from suite 
         """
         runner = next(iter(list(filter(lambda x: "runner.py" in x.filename, inspect.stack()))))
-        return list(runner.frame.f_locals['test'])
+        try:
+            return list(runner.frame.f_locals['test'])
+        except KeyError:
+            return []


### PR DESCRIPTION
When I use TIR with PYTEST, it doesn't use the runner, so the 'test' attribute doesn't exist. I have made a correction that fix that problem.

