### PR TITLE
Creates a internal method to kill service process

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -156,6 +156,8 @@ class WebappInternal(Base):
         >>> # Calling the method:
         >>> oHelper.Setup("SIGAFAT", "18/08/2018", "T1", "D MG 01 ")
         """
+        self.service_process_bat_file()
+        
         if not initial_program:
             self.log_error("Couldn't find The initial program")
 
@@ -203,6 +205,18 @@ class WebappInternal(Base):
 
         if self.config.num_exec:
             self.num_exec.post_exec(self.config.url_set_start_exec)
+
+    def service_process_bat_file(self):
+        """
+        [Internal]
+        This method creates a batfile in the root path to kill the process and its children.
+        """
+        if self.config.smart_test:
+            with open("fox_death.bat", "w", ) as fox_file_death:
+                fox_file_death.write(f"taskkill /f /PID {self.driver.service.process.pid} /T")
+
+
+
 
     def program_screen(self, initial_program="", environment=""):
         """

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -213,8 +213,8 @@ class WebappInternal(Base):
         This method creates a batfile in the root path to kill the process and its children.
         """
         if self.config.smart_test:
-            with open("firefox_death.bat", "w", ) as firefox_file_death:
-                firefox_file_death.write(f"taskkill /f /PID {self.driver.service.process.pid} /T")
+            with open("firefox_task_kill.bat", "w", ) as firefox_task_kill:
+                firefox_task_kill.write(f"taskkill /f /PID {self.driver.service.process.pid} /T")
 
 
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -93,6 +93,7 @@ class WebappInternal(Base):
         """
         print("Starting Setup TSS")
         self.tss = True
+        self.service_process_bat_file()
 
         self.config.initial_program = initial_program
         self.config.environment = enviroment
@@ -212,8 +213,8 @@ class WebappInternal(Base):
         This method creates a batfile in the root path to kill the process and its children.
         """
         if self.config.smart_test:
-            with open("fox_death.bat", "w", ) as fox_file_death:
-                fox_file_death.write(f"taskkill /f /PID {self.driver.service.process.pid} /T")
+            with open("firefox_death.bat", "w", ) as firefox_file_death:
+                firefox_file_death.write(f"taskkill /f /PID {self.driver.service.process.pid} /T")
 
 
 


### PR DESCRIPTION
# Description

This change has been created for an internal process.
If _smart_test = true_ in _Config_ _class(config.json)_ we will generate a bat file called "fox_death" responsible for killing _driver.service.process_ and its children (Firefox instances).


## TSS be implemented
- [x] Yes
- [ ] No

## Type of change

Please delete options that are not relevant.
- [ ] Hotfix - Bug fix (non-breaking change which fixes an issue) 
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

We

- [x] Manual
- [ ] SmartTest

**Test Configuration**:
* Add your description.

### 