### PR TITLE
Change log_path in firefox options to dev/null to geckodriver not cre…

### DIFF
--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -909,7 +909,7 @@ class Base(unittest.TestCase):
         print("Starting the browser")
         if self.config.browser.lower() == "firefox":
             driver_path = os.path.join(os.path.dirname(__file__), r'drivers\\geckodriver.exe')
-            log_path = os.path.join(os.path.dirname(__file__), r'geckodriver.log')
+            log_path = os.devnull
             options = FirefoxOpt()
             options.set_headless(self.config.headless)
             self.driver = webdriver.Firefox(firefox_options=options, executable_path=driver_path, log_path=log_path)


### PR DESCRIPTION
# Description

Change log path in Firefox Option to os.devnull, thus geckodriver.log won't be generated anymore.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Hotfix - Bug fix (non-breaking change which fixes an issue) 
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual
- [ ] SmartTest

**Test Configuration**:
* Add your description.
