### PR TITLE
Fix ScrollGrid method, tables with class 'frozen-table' require a dif…

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -2531,7 +2531,8 @@ class WebappInternal(Base):
         current = get_current()
         td = lambda: next(iter(current.select(f"td[id='{column_index}']")), None)
 
-        if not self.click_grid_td(td()):
+        frozen_table = next(iter(grid.select('table.frozen-table')),None)
+        if (not self.click_grid_td(td()) and not frozen_table):
             self.log_error(" Couldn't click on column, td class or tr is noit selected ")
 
         while( time.time() < endtime and  not td_element ):
@@ -2551,6 +2552,9 @@ class WebappInternal(Base):
         if not td_element:
             self.log_error("Scroll Grid couldn't find the element")
 
+        if frozen_table:
+            self.soup_to_selenium(td_element.nextSibling).click()
+            
         self.try_click(td_element)
 
     def click_grid_td(self, td_soup):

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -2553,7 +2553,7 @@ class WebappInternal(Base):
             self.log_error("Scroll Grid couldn't find the element")
 
         if frozen_table:
-            self.soup_to_selenium(td_element.nextSibling).click()
+            self.soup_to_selenium(td_element.next_sibling).click()
             
         self.try_click(td_element)
 


### PR DESCRIPTION
# Description

 tables with class 'frozen-table' require a different tratament
### fronzen-tables:

- *Line(tr) or Column(td) class don't have a class 'selected' .*

- *The click maybe it has to be on a next sibiling because selenium throw a exception.*

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [x] Hotfix - Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested

- [x] Manual
- [ ] SmartTest

**Test Configuration**:
* Add your description.
