### PR TITLE
russian dict update

### DIFF
--- a/tir/technologies/core/language.py
+++ b/tir/technologies/core/language.py
@@ -300,8 +300,8 @@ class LanguagePack:
             "Exit": "Выход",
             "Leave Page": "Выйти без сохранения",
             "Enter": "Ввод",
-            #"Finish": "Завершить",
-            "Finish": "3акрыть",
+            "Finish": "Завершить",
+            #"Finish": "3акрыть",
             #"Details": "ДЕТАЛИ",
             "Details": "Подробнее",
             #"Search": "Поиск",
@@ -340,9 +340,17 @@ class LanguagePack:
             "Search By": "Search by:",
             "From": "De",
             "To": "Ate",
-            "Coins": "Monedas",
-            "Next": "Avançar >>",
-            "LogOff": "Log Off"
+            "Coins": "Валюта",
+            "Next": "Далее >>",
+            "LogOff": "Завершить",
+            "Checkhelp": "Помощь:",
+            "Checkproblem": "Проблема:",
+            "Checksolution": "Решение:",
+            "ChangePassword": "Смена пароля",
+            "UserLogin": "Пользователь (логин)",
+            "CurrentPassword": "Текущий пароль*",
+            "NewPassword": "Нов. пароль*",
+            "ConfirmNewPassword": "Подтв. новый пароль*"
         }
 
         if language.lower() == "en-us":


### PR DESCRIPTION
# Description

Updated 13 translations for russian version in language package (unable to run tir-framework in russian system without it).

Fixes # (issue)

## Type of change

- [x] Hotfix - Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

On any tir start dropped error: 
**self.checkhelp = languagepack["Checkhelp"]
KeyError: 'Checkhelp'**

To recreate this error force tir to use russian dictionary pack.

- [x] Manual
- [x] SmartTest

**Test Configuration**:
* Add your description.
