### PR TITLE
Fix method SetButton

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -2386,12 +2386,12 @@ class WebappInternal(Base):
                 self.wait_element_timeout(term=".tmodaldialog", scrap_type=enum.ScrapType.CSS_SELECTOR, position=layers + 1, main_container="body", timeout=10, step=0.1, check_error=False)
 
         except ValueError as error:
-            print(error)
+            print(str(error))
             self.log_error(f"Button {button} could not be located.")
         except AssertionError:
             raise
         except Exception as error:
-            print(error)
+            print(str(error))
             self.log_error(str(error))
 
     def set_button_x(self, position=1, check_error=True):


### PR DESCRIPTION
# Description

Fix method SetButton when are an error "unsupported operand type(s) for -=: 'str' and 'int'"

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Hotfix - Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Manual
- [ ] SmartTest

**Test Configuration**:
* Add your description.
