### PR TITLE
fix to allow tir run on docker

### DIFF
--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -976,11 +976,10 @@ class Base(unittest.TestCase):
             if self.config.headless:
                 self.driver.set_window_position(0, 0)
                 self.driver.set_window_size(1024, 768)
-
             else:
                 self.driver.maximize_window()
                 
-            self.driver.get(self.config.url)
+        self.driver.get(self.config.url)
 
         self.wait = WebDriverWait(self.driver, 90)
 

--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -77,7 +77,12 @@ class Base(unittest.TestCase):
         self.language = LanguagePack(self.config.language) if self.config.language else ""
         self.log = Log(folder=self.config.log_folder)
         self.log.station = socket.gethostname()
-        self.log.user = os.getlogin()
+
+        try:
+            self.log.user = os.getlogin()
+        except FileNotFoundError:
+            import getpass
+            self.log.user = getpass.getuser()
 
         self.base_container = "body"
         self.errors = []


### PR DESCRIPTION
# Description

Just protect call of os.getlogin() Python method, this method raise an FileNotFoundError when run from ubuntu docker container. The solution is call getpass.getuser() as mentioned in https://docs.python.org/3/library/os.html#os.getlogin

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [x] Hotfix - Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

docker run --rm -it ubuntu /bin/bash -c 'apt-get update; apt-get install -y python3; python3 -c "import os; os.getlogin()"'

- [x] Manual
