### PR TITLE
hotfix/clickgridCell&FillGrid

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -6466,7 +6466,7 @@ class WebappInternal(Base):
 
                             endtime_click = time.time() + self.config.time_out/2
                             while time.time() < endtime_click and column_element_old_class == column_element().get_attribute("class"):
-                                self.click(column_element(), click_type=enum.ClickType.ACTIONCHAINS) if self.webapp_shadowroot() else self.click(column_element())
+                                self.send_action(action=ActionChains(self.driver).click(column_element()).perform) if self.webapp_shadowroot() else self.click(column_element())
 
                             self.wait_element_is_focused(element_selenium = column_element, time_out = 2)
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -5721,6 +5721,7 @@ class WebappInternal(Base):
         try_counter = 1
         grid_reload = True
         check_value = field[5]
+        grid_class=[]
 
         if (field[1] == True):
             field_one = 'is a boolean value'
@@ -5865,12 +5866,12 @@ class WebappInternal(Base):
 
                             while (time.time() < endtime and not self.element_exists(term=term,scrap_type=enum.ScrapType.CSS_SELECTOR,position=tmodal_layer + 1, main_container='body')):
                                 time.sleep(1)
+                                grid_class= grids[field[2]].attrs['class']
                                 logger().debug('Trying open cell in grid!')
-                                self.scroll_to_element(selenium_column())
-                                self.set_element_focus(selenium_column())
-                                self.click(selenium_column(),
-                                        click_type=enum.ClickType.ACTIONCHAINS) if self.webapp_shadowroot() else self.click(
-                                    selenium_column())
+                                if not 'dict-msbrgetdbase' in grid_class:
+                                    self.scroll_to_element(selenium_column())
+                                    self.set_element_focus(selenium_column())
+                                self.send_action(action=ActionChains(self.driver).click(selenium_column()).perform) if self.webapp_shadowroot() else self.click(selenium_column())
                                 try:
                                     ActionChains(self.driver).move_to_element(selenium_column()).send_keys_to_element(
                                         selenium_column(), Keys.ENTER).perform()


### PR DESCRIPTION
# Description

Mata103- MATA103_020 - #CA-5401

clickgridcell dava setfocus/scroll para a celula ocultando outros grids da tela e impedindo ações futuras em outros grids.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Hotfix - Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Manual
- [ ] SmartTest

**Test Configuration**:
* Add your description.
Ainda é necessario corrigir o mesmo comportamento em outros métodos que utilizam grid