### PR TITLE
hotfix/check_grid_memo

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -6304,12 +6304,19 @@ class WebappInternal(Base):
         :param element:
         :return:
         """
+        term = ".dict-tmultiget" if self.webapp_shadowroot() else "textarea"
+        self.soup_to_selenium(element).click() if type(element) == Tag else element.click()
 
-        self.soup_to_selenium(element).click()
         ActionChains(self.driver).key_down(Keys.ENTER).perform()
         container = self.get_current_container()
-        textarea = next(iter(container.select("textarea")), None)
-        content = self.driver.execute_script(f"return arguments[0].value",self.driver.find_element_by_xpath(xpath_soup(textarea))).strip()
+        textarea = next(iter(container.select(term)), None)
+
+        if self.webapp_shadowroot() and textarea:
+            textarea = next(iter(self.find_shadow_element('textarea', self.soup_to_selenium(textarea))))
+            content = self.driver.execute_script(f"return arguments[0].value",textarea).strip()
+        else:
+            content = self.driver.execute_script(f"return arguments[0].value",self.driver.find_element_by_xpath(xpath_soup(textarea))).strip()
+
         self.SetButton('Ok')
 
         return content


### PR DESCRIPTION
# Description

TASK - CA-5617
Problema ao tentar realizar o check result nos campos memo do grid
MATA410, CT001

Trecho:
39-    self.oHelper.CheckResult("C6_INFAD", "", line=2, grid=True, grid_memo_field=True)
40-    self.oHelper.LoadGrid()

Realizado ajuste no metodo check_grid_memo pois o mesmo nao se encontrava adaptado para nova versao do webapp 

