### PR TITLE
fix clickGridCell

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -6610,6 +6610,12 @@ class WebappInternal(Base):
                             rows = self.driver.execute_script(
                                 "return arguments[0].shadowRoot.querySelectorAll('tbody tr')",
                                 self.soup_to_selenium(grids[grid_number]))
+
+                            if not rows and len(headers) < len(grids):
+                                grids = list(filter(lambda x: self.get_headers_from_grids(x), grids))
+                                rows = self.driver.execute_script(
+                                    "return arguments[0].shadowRoot.querySelectorAll('tbody tr')",
+                                    self.soup_to_selenium(grids[grid_number]))
                         else:
                             rows = grids[grid_number].select("tbody tr")
 


### PR DESCRIPTION
- **Suite**: JURA098
- **CT**: CT001
- **Linha/Trecho**: 
```
self.oHelper.ClickGridCell('Situacao', 1)
```

- **Método Usuario**: ClickGridCell
- **Correção realizada**: o metodo get_headers_from_grids retorna uma lista com um dicionario de headers para cada grid passado, com isso, foi implementado uma verificação onde caso nao encontre nenhuma linha no grid capturado, busque por grids que possuem cabeçalhos.