### PR TITLE
remove send_action and add normal click

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -6009,7 +6009,9 @@ class WebappInternal(Base):
                                 if not 'dict-msbrgetdbase' in grid_class:
                                     self.scroll_to_element(selenium_column())
                                     self.set_element_focus(selenium_column())
-                                self.send_action(self.send_action(action=self.click, element=selenium_column, click_type=3)) if self.webapp_shadowroot() else self.click(selenium_column())
+                                self.click(selenium_column(),
+                                           click_type=enum.ClickType.ACTIONCHAINS) if self.webapp_shadowroot() else self.click(
+                                    selenium_column())
                                 try:
                                     ActionChains(self.driver).move_to_element(selenium_column()).send_keys_to_element(
                                         selenium_column(), Keys.ENTER).perform()


### PR DESCRIPTION
Suite: CRDA010
CT:001
Método Usuário: SetValue
Método Interno: fill_grid
Correção: Remoção do método send_action para efetuar o clique no elemento antes de abrir a célula do grid.
Foi inserido o método de click normal com ActionChains.