### PR TITLE
add set_multilanguage loop.

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -10052,15 +10052,15 @@ class WebappInternal(Base):
     def set_multilanguage(self):
 
         if self.config.poui_login:
-            soup = self.get_current_DOM(twebview=True)
-            po_select = next(iter(soup.select(".po-select-container")), None)
-            if po_select:
-                span_label = next(iter(po_select.select('span')), None)
-                if span_label:
-                    language = self.return_select_language()
-                    if language:
-                        if not span_label.text.lower() in language:
-                            self.set_language_poui(language, po_select)
+
+            soup = lambda: self.get_current_DOM(twebview=True)
+            po_select = lambda: next(iter(soup().select(".po-select-container")), None)
+            span_label = lambda: next(iter(po_select().select('span')), None)
+            language = self.return_select_language()
+            endtime = time.time() + self.config.time_out
+            while time.time() < endtime and not span_label().text.lower() in language:
+                if span_label():
+                    self.set_language_poui(language, po_select())
 
         elif self.webapp_shadowroot():
             if  self.element_exists(term='.dict-tcombobox', scrap_type=enum.ScrapType.CSS_SELECTOR, main_container="body",

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -10059,8 +10059,7 @@ class WebappInternal(Base):
             language = self.return_select_language()
             endtime = time.time() + self.config.time_out
             while time.time() < endtime and not span_label().text.lower() in language:
-                if span_label():
-                    self.set_language_poui(language, po_select())
+                self.set_language_poui(language, po_select())
 
         elif self.webapp_shadowroot():
             if  self.element_exists(term='.dict-tcombobox', scrap_type=enum.ScrapType.CSS_SELECTOR, main_container="body",


### PR DESCRIPTION
Suite: FINA998
CT:
Método : user_screen, set_multilanguage
Problema: Em alguns casos quando usado outro idioma o método set_multilanguage não alterava para o idioma desejado
Correção: Foi inserido um loop com timeout para os casos em que a mudança não foi efetivada.