### PR TITLE
fix columns position

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -7004,6 +7004,7 @@ class WebappInternal(Base):
                     for header in headers:
                         if duplicated_key in header:
                             header[duplicated_key] = duplicated_value if duplicate_fields else index[duplicated_value]
+                index = []
 
         return headers
 


### PR DESCRIPTION
- **Task**: #CA-6219
- **Suite**: FISA800
- **CT**: 001
- **Linha/Trecho**: 
```
		self.oHelper.SetValue("Producto","CI08080000000001",grid=True, grid_number=2,row=1)
		self.oHelper.SetValue("cantidad","1,00",grid=True, grid_number=2,row=1)
		self.oHelper.SetValue("valor unit.","1000,00",grid=True, grid_number=2,row=1)
		self.oHelper.SetValue("valor total","1000,00",grid=True, grid_number=2,row=1)
		self.oHelper.SetValue("tipo salida","501",grid=True, grid_number=2,row=1)
		self.oHelper.LoadGrid()

```
- **Método Usuario**: SetValue/(qualquer um que tenha uso de grid)
- **Correção realizada**: Em casos que possuiam 2 grids exibidos e nesses grids possuissem uma celula com o mesmo nome, o script acabava atribuindo o index do primeiro grid no segundo como padrao.