### PR TITLE
add object driver protection in log_error method

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -7631,7 +7631,7 @@ class WebappInternal(Base):
 
         proceed_action = lambda: ((stack_item != "setUpClass") or (stack_item == "setUpClass" and self.restart_counter == 3))
 
-        if self.config.screenshot and proceed_action() and stack_item not in self.log.test_case_log:
+        if self.config.screenshot and proceed_action() and stack_item not in self.log.test_case_log and self.driver:
             self.log.take_screenshot_log(self.driver, stack_item, test_number)
             time.sleep(1)
 
@@ -7645,7 +7645,8 @@ class WebappInternal(Base):
             self.restart()
         else:
             try:
-                self.driver.close()
+                if self.driver:
+                    self.driver.close()
             except Exception as e:
                 logger().exception(f"Warning Log Error Close {str(e)}")
 
@@ -7661,7 +7662,8 @@ class WebappInternal(Base):
 
             if (stack_item == "setUpClass") :
                 try:
-                    self.driver.close()
+                    if self.driver:
+                        self.driver.close()
                 except Exception as e:
                     logger().exception(f"Warning Log Error Close {str(e)}")
 


### PR DESCRIPTION
Issue: Quando ocorre algum erro na construção do objeto self.driver, o objeto fica como None causando erro nas condições que dependem desse objeto.
Hotfix: Inserido condição no método log_error para verificar se o objeto self.driver tem algum algum conteúdo.