### PR TITLE
change "File Name" dict language for es-es

### DIFF
--- a/tir/technologies/core/language.py
+++ b/tir/technologies/core/language.py
@@ -298,7 +298,7 @@ class LanguagePack:
             "ConfirmNewPassword": "Confirmar nueva contrasena*",
             "Yes":"Reserved",
             "AssertFalseMessage": "Método AssertFalse utilizado sin un punto de control, verifique el script.",
-            "File Name": "Nombre del archivo:",
+            "File Name": "Nome do Arquivo",
 			"Open": "Abierto",
             "Warning": "Atención",
             "News": "Noticias",


### PR DESCRIPTION
Issue: Dicionário language com conteúdo errado para o idioma es-es.
HotFix: Ajuste no dicionario de idiomas para refletir o text correto.