### PR TITLE
Hotfix/get grid

### DIFF
--- a/tir/main.py
+++ b/tir/main.py
@@ -1317,15 +1317,19 @@ class Webapp():
 
         :param grid_number: The number of the grid on the screen.
         :type: int
-        :param grid_element: Grid class name in HTML ex: ".tgrid".
+        :param grid_element: Grid class name in HTML ex: ".tgrid" Default:If None return all webapp classes.
         :type: str
         :return: Grid BeautifulSoup object
         :rtype: BeautifulSoup object
+
+        Class css selector sintaxe:
+        .class	.intro	Selects all elements with class="intro"
 
         Usage:
 
         >>> # Calling the method:
         >>> my_grid = self.get_grid()
+        >>> my_grid = self.get_grid(grid_element='.dict-msbrgetdbase')
         """
         
         return self.__webapp.get_grid_content(grid_number, grid_element)

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -10192,12 +10192,20 @@ class WebappInternal(Base):
         """
 
         grid_number -= 1
+        grid_list = []
 
-        self.wait_element(term=".tgetdados tbody tr, .tgrid tbody tr, .tcbrowse",
+        self.wait_element(self.grid_selectors['new_web_app']+f', {grid_element}',
                           scrap_type=enum.ScrapType.CSS_SELECTOR)
         grid = self.get_grid(grid_number, grid_element)
 
-        return grid.select('tbody tr')
+        if grid:
+            tr = grid.select('tbody tr')
+            if tr:
+                grid_list.append(grid.select('tbody tr'))
+            else:
+                grid_list.append(grid)
+
+        return grid_list
 
     def LengthGridLines(self, grid):
         """


### PR DESCRIPTION
Issue: Método GetGrid estava com a definição de seletores incorreta no método wait_element.
Hotfix: Ajuste na definição de classes e retorno do método para que a lista retorne o valor correto.