### PR TITLE
hotfix grid double enter

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -6007,6 +6007,15 @@ class WebappInternal(Base):
                                                                                                                     headers,
                                                                                                                     field_to_label)
 
+                            if self.webapp_shadowroot():
+                                term = "wa-multi-get" if self.grid_memo_field else "wa-dialog"
+                            else:
+                                term = ".tmodaldialog"
+
+                            soup = self.get_current_DOM()
+                            tmodal_list = soup.select(term)
+                            tmodal_layer = len(tmodal_list) if tmodal_list else 0
+
                             self.scroll_to_element(selenium_column())
                             self.click(selenium_column(),
                                     click_type=enum.ClickType.ACTIONCHAINS) if self.webapp_shadowroot() else self.click(
@@ -6021,15 +6030,6 @@ class WebappInternal(Base):
                                     selenium_column())
                                 self.set_element_focus(selenium_column())
                                 time.sleep(1)
-
-                            if self.webapp_shadowroot():
-                                term = "wa-multi-get" if self.grid_memo_field else "wa-dialog"
-                            else:
-                                term = ".tmodaldialog"
-
-                            soup = self.get_current_DOM()
-                            tmodal_list = soup.select(term)
-                            tmodal_layer = len(tmodal_list) if tmodal_list else 0
 
                             endtime_open_cell = time.time() + self.config.time_out / 3
                             while (time.time() < endtime_open_cell and not self.element_exists(term=term,scrap_type=enum.ScrapType.CSS_SELECTOR,position=tmodal_layer + 1, main_container='body')):


### PR DESCRIPTION
- **Task**: 
- **Suite**: MATA805,TECA700
- **CT**: 
- **Linha/Trecho**: 
```
```
- **Método Usuario**: 
- **Correção realizada**:  Algumas vezes ao executar o preenchimento de uma grid, o click de seleção que precede o enter para abertura de celula acaba abrindo a celula, sendo assim agora a atribuição dos layers disponiveis é feita antes do click para seleção da celula