### PR TITLE
hotfix/clickGridCell attempts

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -6639,6 +6639,7 @@ class WebappInternal(Base):
         rows = None
         same_location = False
         term = self.grid_selectors['new_web_app'] if self.webapp_shadowroot() else ".tgetdados, .tgrid, .tcbrowse"
+        click_attempts = 0
 
         logger().info(f"Clicking on grid cell: {column}")
 
@@ -6721,6 +6722,9 @@ class WebappInternal(Base):
                             endtime_click = time.time() + self.config.time_out/2
                             while time.time() < endtime_click and column_element_old_class == column_element().get_attribute("class"):
                                 self.send_action(action=self.click, element=column_element, click_type=3, wait_change=False) if self.webapp_shadowroot() else self.click(column_element())
+                                click_attempts += 1
+                                if column_number == 0 and click_attempts > 3:
+                                    break
 
                             self.wait_element_is_focused(element_selenium = column_element, time_out = 2)
 


### PR DESCRIPTION
Por algum motivo, a primeira celula/coluna do grid  sempre é exibida como selected no html, mesmo nao estando selecionada, isso faz com que em alguns casos o metodo nao consiga validar a alteração realizada ao clicar na celula, para esses casos foi posto uma validação fixa de 4 tentativas