### PR TITLE
hotfix setvalue/combox

### DIFF
--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -784,7 +784,9 @@ class Base(unittest.TestCase):
                 time.sleep(1)
                 combo.select_by_index(str(index_number))
         else:
-            value = next(iter(filter(lambda x: x.text[0:len(option)].lower() == option.lower(), combo.options)), None)
+            value = next(iter(filter(lambda x: x.text.lower().strip() == option.lower().strip() , combo.options)), None)
+            if not value:
+                value = next(iter(filter(lambda x: x.text[0:len(option)].lower().strip()  == option.lower().strip() , combo.options)), None)
             if value:
                 time.sleep(1)
                 text_value = value.text


### PR DESCRIPTION
- **Task**: #CA-6679
- **Suite**: MATA103
- **CT**: MATA103_037
- **Linha/Trecho da suite**: 
```
self.oHelper.SetValue("Quanto ao PC ?", "Fornecedor")
```
- **Método Usuario**: SetValue
- **Correção realizada**: ao tentar filtrar o item informado, em casos onde possuiam mais de um item iniciando com o mesmo nome ocorria um conflito.