### PR TITLE
Hotfix/click table po UI

### DIFF
--- a/tir/main.py
+++ b/tir/main.py
@@ -1641,7 +1641,7 @@ class Poui():
         """
         self.__poui.POSearch(content, placeholder)
 
-    def ClickTable(self, first_column=None, second_column=None, first_content=None, second_content=None, table_number=0, itens=False, click_cell=None, checkbox=False):
+    def ClickTable(self, first_column=None, second_column=None, first_content=None, second_content=None, table_number=1, itens=False, click_cell=None, checkbox=False):
         """
         Clicks on the Table of POUI component.
         https://po-ui.io/documentation/po-table

--- a/tir/main.py
+++ b/tir/main.py
@@ -1641,7 +1641,7 @@ class Poui():
         """
         self.__poui.POSearch(content, placeholder)
 
-    def ClickTable(self, first_column=None, second_column=None, first_content=None, second_content=None, table_number=0, itens=False, click_cell=None):
+    def ClickTable(self, first_column=None, second_column=None, first_content=None, second_content=None, table_number=0, itens=False, click_cell=None, checkbox=False):
         """
         Clicks on the Table of POUI component.
         https://po-ui.io/documentation/po-table
@@ -1660,13 +1660,15 @@ class Poui():
         :type itens: bool
         :param click_cell: Content to click based on a column position to close the axis
         :type click_cell: str
+        :param checkbox: If you want to click on the checkbox component in the table
+        :type checkbox: bool
 
         >>> # Call the method:
         >>> oHelper.ClickTable(first_column='Código', first_content='000003', click_cell='Editar')
         :return: None
         """
 
-        self.__poui.ClickTable(first_column, second_column, first_content, second_content, table_number, itens, click_cell)
+        self.__poui.ClickTable(first_column, second_column, first_content, second_content, table_number, itens, click_cell, checkbox)
         
     def CheckResult(self, field=None, user_value=None, po_component='po-input', position=1):
         """

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -2453,61 +2453,6 @@ class PouiInternal(Base):
             self.assertTrue(False, self.message)
 
         self.message = ""
-                
-    def TearDown(self):
-        """
-        Closes the webdriver and ends the test case.
-
-        Usage:
-
-        >>> #Calling the method
-        >>> self.TearDown()
-        """
-
-        if self.config.new_log:
-            self.execution_flow()
-
-        webdriver_exception = None
-        timeout = 1500
-        string = "Aguarde... Coletando informacoes de cobertura de codigo."
-
-        if self.config.coverage:
-            try:
-                self.driver_refresh()
-            except WebDriverException as e:
-                logger().exception(str(e))
-                webdriver_exception = e
-
-            if webdriver_exception:
-                message = f"Wasn't possible execute self.driver.refresh() Exception: {next(iter(webdriver_exception.msg.split(':')), None)}"
-                logger().debug(message)
-
-            if not webdriver_exception and not self.tss:
-                self.wait_element(term="[name='cGetUser']", scrap_type=enum.ScrapType.CSS_SELECTOR, main_container='body')
-                self.user_screen()
-                self.environment_screen()
-                endtime = time.time() + self.config.time_out
-                while (time.time() < endtime and (
-                not self.element_exists(term=".tmenu", scrap_type=enum.ScrapType.CSS_SELECTOR, main_container="body"))):
-                    self.close_warning_screen()
-                self.Finish()
-            elif not webdriver_exception:
-                self.SetupTSS(self.config.initial_program, self.config.environment )
-                self.SetButton(self.language.exit)
-                self.SetButton(self.language.yes)
-
-            if (self.search_text(selector=".tsay", text=string) and not webdriver_exception):
-                self.WaitProcessing(string, timeout)
-
-        if self.config.num_exec:
-            if not self.num_exec.post_exec(self.config.url_set_end_exec, 'ErrorSetFimExec'):
-                self.restart_counter = 3
-                self.log_error(f"WARNING: Couldn't possible send num_exec to server please check log.")
-
-        try:
-            self.driver.close()
-        except Exception as e:
-            logger().exception(f"Warning tearDown Close {str(e)}")
             
     def containers_filter(self, containers):
         """

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3559,7 +3559,7 @@ class PouiInternal(Base):
                                                element=first_element_focus, locator=By.XPATH)
                             self.soup_to_selenium(first_element_focus).click()
                         ActionChains(self.driver).key_down(Keys.PAGE_DOWN).perform()
-                        table = self.return_table(selector=term)
+                        table = self.return_table(selector=term, table_number=table_number)
                         df = self.data_frame(object=table)
                         if df.equals(last_df):
                             count += 1
@@ -3575,7 +3575,7 @@ class PouiInternal(Base):
         if hasattr(index_number, '__iter__'):
             for index in index_number:
                 if checkbox:
-                    self.click_checkbox(selector=term, index=index)
+                    self.click_checkbox(selector=term, index=index, table_number=table_number)
                 else:
                     if column_index_number:
                         element_bs4 = tr[index].select('td')[column_index_number].select('span')[0]
@@ -3587,14 +3587,14 @@ class PouiInternal(Base):
             element_bs4 = next(iter(tr[index].select('td')))
             self.poui_click(element_bs4)
 
-    def click_checkbox(self, selector, index):
+    def click_checkbox(self, selector, index, table_number):
 
         checked = False
 
         endtime = time.time() + self.config.time_out
         while time.time() < endtime and not checked:
 
-            table = self.return_table(selector=selector)
+            table = self.return_table(selector=selector, table_number=table_number)
 
             tr = table.select('tbody > tr')
 


### PR DESCRIPTION
Inserido a funcionalidade de clicar no componente checkbox dentro do método ClickTable da classe POUI.
Inserido o controle de table_number para múltiplas tabelas na tela.
Método table_dataframe divido em dois métodos, cada uma com a sua responsabilidade.

Modificação atrelada à Task CA-6796 do Ryver