### PR TITLE
add testsuite and testcase param in config

### DIFF
--- a/tir/technologies/core/config.py
+++ b/tir/technologies/core/config.py
@@ -86,4 +86,7 @@ class ConfigLoader:
         self.chromedriver_auto_install = ("ChromeDriverAutoInstall" in data and bool(data["ChromeDriverAutoInstall"]))
         self.ssl_chrome_auto_install_disable = (
                     "SSLChromeInstallDisable" in data and bool(data["SSLChromeInstallDisable"]))
+
         self.data_delimiter = str(data["DataDelimiter"]) if "DataDelimiter" in data else "/"
+        self.suite_prefix = str(data["SuitePrefix"]) if "SuitePrefix" in data else "testsuite"
+        self.test_prefix = str(data["TestPrefix"]) if "TestPrefix" in data else "testcase"

--- a/tir/technologies/core/log.py
+++ b/tir/technologies/core/log.py
@@ -116,9 +116,9 @@ class Log:
         >>> # Calling the method:
         >>> self.log.save_file()
         """
-        
+
         log_file = f"{self.user}_{uuid.uuid4().hex}_auto.csv"
-                
+
         if len(self.table_rows) > 0:
             try:
                 if self.folder:
@@ -139,7 +139,7 @@ class Log:
 
             logger().debug(f"Log file created successfully: {os.path.join(path, log_file)}")
 
-                            
+
             self.csv_log.append(self.get_testcase_stack())
 
     def log_exec_file(self):
@@ -189,7 +189,7 @@ class Log:
 
     def list_of_testcases(self):
         """
-        Returns a list of test cases from suite 
+        Returns a list of test cases from suite
         """
         runner = next(iter(list(filter(lambda x: "runner.py" in x.filename, inspect.stack()))), None)
 
@@ -211,7 +211,7 @@ class Log:
     def checks_empty_line(self):
         """
         Checks if the log file is not empty.
-        03 - 'Programa'  10 - 'Release' 14 - 'ID Execução' 15 - 'Pais' 
+        03 - 'Programa'  10 - 'Release' 14 - 'ID Execução' 15 - 'Pais'
         [Internal]
         """
         table_rows_has_line = False
@@ -314,8 +314,8 @@ class Log:
             "SOVERSION": self.so_version,
             "STATION": self.station,
             "STATUS": "", # ???
-            "TESTCASE": self.get_file_name('testcase'),
-            "TESTSUITE": self.get_file_name('testsuite'),
+            "TESTCASE": self.get_file_name(self.config.test_prefix),
+            "TESTSUITE": self.get_file_name(self.config.suite_prefix),
             "TESTTYPE": "1",
             "TOKEN": "TIR4541c86d1158400092A6c7089cd9e9ae-2020", # ???
             "TOOL": self.test_type,
@@ -384,7 +384,7 @@ class Log:
         """
 
         today = datetime.today()
-        
+
         try:
             path = Path(self.folder, "new_log", self.station)
             os.makedirs(path)
@@ -464,7 +464,7 @@ class Log:
             stack_item = self.get_testcase_stack()
 
         if stack_item == "setUpClass":
-            stack_item = f'{self.get_testcase_stack()}_{self.get_file_name("testsuite")}'
+            stack_item = f'{self.get_testcase_stack()}_{self.get_file_name(self.config.suite_prefix)}'
 
         if not test_number:
             test_number = f"{stack_item.split('_')[-1]} -" if stack_item else ""
@@ -472,7 +472,7 @@ class Log:
         if not self.release:
             self.release = self.config.release
 
-        testsuite = self.get_file_name("testsuite")
+        testsuite = self.get_file_name(self.config.suite_prefix)
 
         today = datetime.today()
 
@@ -485,7 +485,7 @@ class Log:
 
         if self.config.debug_log:
             logger().debug(f"take_screenshot_log in:{datetime.now()}\n")
-            
+
         try:
             if self.config.log_http:
                 folder_path = Path(self.config.log_http, self.config.country, self.release, self.config.issue, self.config.execution_id, testsuite)

--- a/tir/technologies/core/logging_config.py
+++ b/tir/technologies/core/logging_config.py
@@ -33,7 +33,7 @@ def logger(logger='root'):
         file_handler = True if logger == 'root' else False
 
         if not file_path and file_handler:
-            filename = f"TIR_{get_file_name('testsuite')}_{today.strftime('%Y%m%d%H%M%S%f')[:-3]}.log"
+            filename = f"TIR_{get_file_name(config.suite_prefix)}_{today.strftime('%Y%m%d%H%M%S%f')[:-3]}.log"
 
             folder = create_folder()
 
@@ -129,7 +129,7 @@ def create_folder():
     try:
         if config.log_http:
             folder_path = Path(config.log_http, config.country, config.release, config.issue,
-                               config.execution_id, get_file_name('testsuite'))
+                               config.execution_id, get_file_name(config.suite_prefix))
             path = Path(folder_path)
             os.makedirs(Path(folder_path))
         else:

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -105,7 +105,7 @@ class WebappInternal(Base):
         self.range_multiplier = None
         self.routine = None
         self.test_suite = []
-        self.current_test_suite = self.log.get_file_name('testsuite')
+        self.current_test_suite = self.log.get_file_name(self.config.suite_prefix)
 
         if not Base.driver:
             Base.driver = self.driver


### PR DESCRIPTION

# Description

added a variable for the testsuite and testcase name prefix
We have a slightly different architecture (testsuite and testcase can be one file) and therefore the prefix is different. The default setting is set to the same as yours, so nothing should break

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Hotfix - Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Manual
- [ ] SmartTest

**Test Configuration**:
* Add your description.
