### PR TITLE
position label correct

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -2405,9 +2405,9 @@ class WebappInternal(Base):
 
             label_s  = lambda:self.soup_to_selenium(label)
             if self.webapp_shadowroot():
-                xy_label = label_s().location
+                xy_label = lambda: label_s().location
             else:
-                xy_label =  self.driver.execute_script('return arguments[0].getPosition()', label_s())
+                xy_label = lambda: self.driver.execute_script('return arguments[0].getPosition()', label_s())
 
             if input_field:
                 active_tab = self.filter_active_tabs(container)
@@ -2453,8 +2453,8 @@ class WebappInternal(Base):
                     list_in_range = list(filter(lambda x: field.strip().lower() != x.text.strip().lower(), list_in_range))
 
             position_list = list(map(lambda x:(x[0], self.get_position_from_bs_element(x[1])), enumerate(list_in_range)))
-            position_list = self.filter_by_direction(xy_label, width_safe, height_safe, position_list, direction)
-            distance      = self.get_distance_by_direction(xy_label, position_list, direction)
+            position_list = self.filter_by_direction(xy_label(), width_safe, height_safe, position_list, direction)
+            distance      = self.get_distance_by_direction(xy_label(), position_list, direction)
             if distance:
                 elem          = min(distance, key = lambda x: abs(x[1]))
                 elem          = list_in_range[elem[0]]


### PR DESCRIPTION
ao fazer um web_scraping nas labels de input , o metodo scrollava a tela, assim alterando o position das labels anteriormente capturadas, impossibilitando  a captura correta do elemento mais proximo