### PR TITLE
remove reversed rows

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -7530,8 +7530,6 @@ class WebappInternal(Base):
                 filtered_rows = list(filter(lambda x: "selected-row" == self.soup_to_selenium(x).get_attribute('class'), rows))
                 if filtered_rows:
                     return next(iter(list(filter(lambda x: "selected-row" == self.soup_to_selenium(x).get_attribute('class'), rows))), None)
-        logger().debug(f'Get selected row- reversed rows {rows}')
-        return next(reversed(rows), None)
 
 
     def SetFilePath(self, value, button = ""):


### PR DESCRIPTION
SUITE : OGA450
TESTCASE: 004

Descrição:
Devido a uma alteração no componente de grid , Ao tentar capturar a linha 1 do grid o mesmo acabava pegando incorretamente a ultima linha.