### PR TITLE
 back reversed and rows grid fix

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -6154,7 +6154,7 @@ class WebappInternal(Base):
                 else:
                     self.log_error("Grid element doesn't appear in DOM")
 
-                row = rows[field[4]] if field[4] else self.get_selected_row(rows) if self.get_selected_row(rows) else (
+                row = rows[field[4]] if field[4] is not None else self.get_selected_row(rows) if self.get_selected_row(rows) else (
                     next(iter(rows), None))
 
                 if row:
@@ -7530,6 +7530,7 @@ class WebappInternal(Base):
                 filtered_rows = list(filter(lambda x: "selected-row" == self.soup_to_selenium(x).get_attribute('class'), rows))
                 if filtered_rows:
                     return next(iter(list(filter(lambda x: "selected-row" == self.soup_to_selenium(x).get_attribute('class'), rows))), None)
+        return next(reversed(rows), None)
 
 
     def SetFilePath(self, value, button = ""):


### PR DESCRIPTION
SUITE : OGA450, MATA105
TESTCASE: 004; 001

Descrição:
Devido a uma alteração no componente de grid , Ao tentar capturar a linha 1 do grid o mesmo acabava pegando incorretamente a ultima linha.
