### PR TITLE
hotfix chrome combobox triggers

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -2803,6 +2803,10 @@ class WebappInternal(Base):
                            self.select_combo(element, main_value, index=True)
                         else:
                             self.select_combo(element, main_value)
+                        if self.config.browser.lower() == 'chrome':  # TODO to monitor ATFA005 behavior
+                            self.set_element_focus(input_field())
+                            ActionChains(self.driver).send_keys(Keys.ENTER).perform()
+
                         current_value = self.return_selected_combo_value(element).strip()
                     #Action for Input elements
                     else:


### PR DESCRIPTION
atfa005- ok
acda030- ok
acda100- ok
MATA119 - ok
 
Combobox usadas como gatilho para outros campos, alteram o valor, porém nao ativam os campos dependentes.