### PR TITLE
fix po-tabs search

### DIFF
--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3612,7 +3612,7 @@ class PouiInternal(Base):
 
         self.wait_element(term="[class='po-tabs-container']", scrap_type=enum.ScrapType.CSS_SELECTOR)
 
-        po_tab_button = self.web_scrap(term="[class='po-tab-button']", scrap_type=enum.ScrapType.CSS_SELECTOR,
+        po_tab_button = self.web_scrap(term="po-tab-button", scrap_type=enum.ScrapType.CSS_SELECTOR,
                                        main_container='body')
 
         label_element = next(


### PR DESCRIPTION
devido a algumas classes serem compostas por varios nomes, o método de captura nao encontrava em especifico a mencionada.
Foi implementado a captura pela TAG elemento.

SUITE FINA710 - CT003