### PR TITLE
Hotfix/fill date

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -862,13 +862,17 @@ class WebappInternal(Base):
 
                     self.wait_blocker()
                     for i in range(3):
+                        self.take_screenshot(f'fill_data_before_click{click_type}_{time.time()}')
                         self.click(date(), click_type=enum.ClickType(click_type))
+                        self.take_screenshot(f'fill_data_after_click{click_type}_{time.time()}')
 
                         ActionChains(self.driver).key_down(Keys.CONTROL).send_keys(Keys.HOME).key_up(Keys.CONTROL).perform()
                         ActionChains(self.driver).key_down(Keys.CONTROL).key_down(Keys.SHIFT).send_keys(
                             Keys.END).key_up(Keys.CONTROL).key_up(Keys.SHIFT).perform()
 
+                        self.take_screenshot(f'fill_data_before_send{click_type}_{time.time()}')
                         self.try_send_keys(date, self.config.date, try_counter=send_type)
+                        self.take_screenshot(f'fill_data_after_send{click_type}_{time.time()}')
 
                         base_date_value = self.merge_date_mask(self.config.date, self.get_web_value(date()))
                         if self.config.poui_login:

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -870,9 +870,9 @@ class WebappInternal(Base):
                         ActionChains(self.driver).key_down(Keys.CONTROL).key_down(Keys.SHIFT).send_keys(
                             Keys.END).key_up(Keys.CONTROL).key_up(Keys.SHIFT).perform()
 
-                        self.take_screenshot(f'fill_data_before_send{click_type}_{time.time()}')
+                        self.take_screenshot(f'fill_data_before_send{send_type}_{time.time()}')
                         self.try_send_keys(date, self.config.date, try_counter=send_type)
-                        self.take_screenshot(f'fill_data_after_send{click_type}_{time.time()}')
+                        self.take_screenshot(f'fill_data_after_send{send_type}_{time.time()}')
 
                         base_date_value = self.merge_date_mask(self.config.date, self.get_web_value(date()))
                         if self.config.poui_login:

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -825,6 +825,7 @@ class WebappInternal(Base):
         click_type = 1
         send_type = 1
         base_date_value = ''
+        is_active_element = None
         endtime = time.time() + self.config.time_out / 2
         while (time.time() < endtime and (base_date_value.strip() != self.config.date.strip())):
 
@@ -862,31 +863,31 @@ class WebappInternal(Base):
 
                     self.wait_blocker()
                     for i in range(3):
-                        self.take_screenshot(f'fill_data_before_click{click_type}_{time.time()}')
+                        time.sleep(1)
                         self.click(date(), click_type=enum.ClickType(click_type))
-                        self.take_screenshot(f'fill_data_after_click{click_type}_{time.time()}')
-
                         ActionChains(self.driver).key_down(Keys.CONTROL).send_keys(Keys.HOME).key_up(Keys.CONTROL).perform()
                         ActionChains(self.driver).key_down(Keys.CONTROL).key_down(Keys.SHIFT).send_keys(
                             Keys.END).key_up(Keys.CONTROL).key_up(Keys.SHIFT).perform()
 
-                        self.take_screenshot(f'fill_data_before_send{send_type}_{time.time()}')
                         self.try_send_keys(date, self.config.date, try_counter=send_type)
-                        self.take_screenshot(f'fill_data_after_send{send_type}_{time.time()}')
 
                         base_date_value = self.merge_date_mask(self.config.date, self.get_web_value(date()))
                         if self.config.poui_login:
                             ActionChains(self.driver).send_keys(Keys.TAB * 2).perform()
 
-                        time.sleep(1)
-                        click_type += 1
-                        if click_type > 3:
-                            click_type = 1
+                        send_type += 1
+                        if send_type > 3:
+                            send_type = 1
+
                         if base_date_value.strip() == self.config.date.strip():
                             break
-                send_type += 1
-                if send_type > 3:
-                    send_type = 1
+
+                        if not self.is_active_element(date()) and click_type == 3:
+                            self.filling_group(shadow_root, container)
+
+                click_type += 1
+                if click_type > 3:
+                    click_type = 1
 
     def filling_group(self, shadow_root=None, container=None):
         """

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -861,26 +861,28 @@ class WebappInternal(Base):
                     logger().info(f'Filling Date: "{self.config.date}"')
 
                     self.wait_blocker()
-                    self.click(date(), click_type=enum.ClickType(click_type))
-                    ActionChains(self.driver).key_down(Keys.CONTROL).send_keys(Keys.HOME).key_up(Keys.CONTROL).perform()
-                    ActionChains(self.driver).key_down(Keys.CONTROL).key_down(Keys.SHIFT).send_keys(
-                        Keys.END).key_up(Keys.CONTROL).key_up(Keys.SHIFT).perform()
+                    for i in range(3):
+                        self.click(date(), click_type=enum.ClickType(click_type))
 
+                        ActionChains(self.driver).key_down(Keys.CONTROL).send_keys(Keys.HOME).key_up(Keys.CONTROL).perform()
+                        ActionChains(self.driver).key_down(Keys.CONTROL).key_down(Keys.SHIFT).send_keys(
+                            Keys.END).key_up(Keys.CONTROL).key_up(Keys.SHIFT).perform()
 
-                    self.try_send_keys(date, self.config.date, try_counter=send_type)
+                        self.try_send_keys(date, self.config.date, try_counter=send_type)
 
+                        base_date_value = self.merge_date_mask(self.config.date, self.get_web_value(date()))
+                        if self.config.poui_login:
+                            ActionChains(self.driver).send_keys(Keys.TAB * 2).perform()
 
-                    base_date_value = self.merge_date_mask(self.config.date, self.get_web_value(date()))
-                    if self.config.poui_login:
-                        ActionChains(self.driver).send_keys(Keys.TAB * 2).perform()
-
-                    time.sleep(1)
-                    click_type += 1
-                    send_type += 1
-                    if click_type > 3:
-                        click_type = 1
-                    if send_type > 3:
-                        send_type = 1
+                        time.sleep(1)
+                        click_type += 1
+                        if click_type > 3:
+                            click_type = 1
+                        if base_date_value.strip() == self.config.date.strip():
+                            break
+                send_type += 1
+                if send_type > 3:
+                    send_type = 1
 
     def filling_group(self, shadow_root=None, container=None):
         """

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -863,7 +863,6 @@ class WebappInternal(Base):
 
                     self.wait_blocker()
                     for i in range(3):
-                        time.sleep(1)
                         self.click(date(), click_type=enum.ClickType(click_type))
                         ActionChains(self.driver).key_down(Keys.CONTROL).send_keys(Keys.HOME).key_up(Keys.CONTROL).perform()
                         ActionChains(self.driver).key_down(Keys.CONTROL).key_down(Keys.SHIFT).send_keys(
@@ -875,6 +874,7 @@ class WebappInternal(Base):
                         if self.config.poui_login:
                             ActionChains(self.driver).send_keys(Keys.TAB * 2).perform()
 
+                        time.sleep(1)
                         send_type += 1
                         if send_type > 3:
                             send_type = 1


### PR DESCRIPTION
Corrige casos intermitentes onde devido a velocidade de abertura da tela o campo de data acabava nao conseguindo ser focado corretamente, isso fazia com que uma ação fizesse o grupo ser  preenchido incorretamente travando o campo de data.

Suite ATFA251