### PR TITLE
Hotfix/clicktable

### DIFF
--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3555,7 +3555,11 @@ class PouiInternal(Base):
                     else:
                         element_bs4 = next(iter(tr[index].select('td')))
                         if first_column == UNNAMED_COLUMN:
-                            element_bs4 = tr[index].select('td')[0].select('.po-clickable')[0]
+                            clickable_spans = tr[index].select('td')[0].select('.po-clickable')
+                            if clickable_spans:
+                                element_bs4 = clickable_spans[0]
+                            else:
+                                self.log_error("No clickable spans found in the table row.")
                     self.poui_click(element_bs4)
         else:
             index = index_number

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3471,6 +3471,7 @@ class PouiInternal(Base):
         :return: None
         """
         element = None
+        UNNAMED_COLUMN = 'Unnamed: 0'
 
         if not self.config.poui:
             self.twebview_context = True
@@ -3496,7 +3497,7 @@ class PouiInternal(Base):
                     if click_cell:
                         column_index_number = df.columns.get_loc(click_cell)
 
-                    if first_column and second_column and first_column != 'Unnamed: 0':
+                    if first_column and second_column and first_column != UNNAMED_COLUMN:
                         index_number = df.loc[(df[first_column] == first_content) & (df[second_column] == second_content)].index.array
                     elif first_column and (first_content and second_content):
                         index_number = df.loc[(df[first_column[0]] == first_content) | (df[first_column[0]] == second_content)].index.array
@@ -3553,7 +3554,7 @@ class PouiInternal(Base):
 
                     else:
                         element_bs4 = next(iter(tr[index].select('td')))
-                        if first_column == 'Unnamed: 0':
+                        if first_column == UNNAMED_COLUMN:
                             element_bs4 = tr[index].select('td')[0].select('.po-clickable')[0]
                     self.poui_click(element_bs4)
         else:

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3496,7 +3496,7 @@ class PouiInternal(Base):
                     if click_cell:
                         column_index_number = df.columns.get_loc(click_cell)
 
-                    if first_column and second_column:
+                    if first_column and second_column and first_column != 'Unnamed: 0':
                         index_number = df.loc[(df[first_column] == first_content) & (df[second_column] == second_content)].index.array
                     elif first_column and (first_content and second_content):
                         index_number = df.loc[(df[first_column[0]] == first_content) | (df[first_column[0]] == second_content)].index.array
@@ -3509,6 +3509,15 @@ class PouiInternal(Base):
                         content = next(iter(list(filter(lambda x: x == first_content.replace(' ', ''), first_column_formatted_values))), None)
                         if content:
                             index_number.append(first_column_formatted_values.index(content))
+                            if len(index_number) > 0:
+                                index_number = [index_number[0]]
+                    elif first_column and second_column and second_content:
+                        second_column = next(iter(list(filter(lambda x: second_column.lower().strip() in x.lower().strip(), df.columns))))
+                        second_column_values = df[second_column].values
+                        second_column_formatted_values = list(map(lambda x: x.replace(' ', ''), second_column_values))
+                        content = next(iter(list(filter(lambda x: x == second_content.replace(' ', ''), second_column_formatted_values))), None)
+                        if content:
+                            index_number.append(second_column_formatted_values.index(content))
                             if len(index_number) > 0:
                                 index_number = [index_number[0]]
                     else:
@@ -3541,8 +3550,11 @@ class PouiInternal(Base):
                 else:
                     if column_index_number:
                         element_bs4 = tr[index].select('td')[column_index_number].select('span')[0]
+
                     else:
                         element_bs4 = next(iter(tr[index].select('td')))
+                        if first_column == 'Unnamed: 0':
+                            element_bs4 = tr[index].select('td')[0].select('.po-clickable')[0]
                     self.poui_click(element_bs4)
         else:
             index = index_number


### PR DESCRIPTION
# Description

Commit to handling cases where the component on screen contains unnamed columns.

Issue Fixed:
CA-10177
Fixes cases where data is displayed with columns lacking headers, which may cause confusion or hinder usability.

Motivation and Context:
Certain screens/components are rendering tables with one or more columns that lack defined names. This change ensures such cases are properly addressed, improving data clarity and user experience.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Hotfix - Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

The changes were verified using the FSMA001TESTCASE.py test suite.

- [ ] Manual
- [ ] SmartTest

**Test Configuration**:
* Add your description.
