### PR TITLE
Hotfix/click tree

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -9235,7 +9235,7 @@ class WebappInternal(Base):
                                                 if not success:
                                                     success = True if is_element_acessible() else False
 
-                                                    # If throug last click some dialog layers show up',
+                                                    # If dialog layers show up throug last click',
                                                     if not success and dialog_layers < self.check_layers('wa-dialog'):
                                                         success = True
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -9438,7 +9438,7 @@ class WebappInternal(Base):
 
         if self.webapp_shadowroot():
             bs_tree_node = container.select('wa-tree')
-            if bs_tree_node:
+            if bs_tree_node and len(bs_tree_node) > tree_number:
                 tr = self.driver.execute_script(f"return arguments[0].shadowRoot.querySelectorAll('wa-tree-node')", self.soup_to_selenium(bs_tree_node[tree_number]))
             return tr
         else:

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -9235,7 +9235,7 @@ class WebappInternal(Base):
                                                 if not success:
                                                     success = True if is_element_acessible() else False
 
-                                                    # If dialog layers show up throug last click',
+                                                    # If dialog layers show up through last click
                                                     if not success and dialog_layers < self.check_layers('wa-dialog'):
                                                         success = True
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -9138,6 +9138,7 @@ class WebappInternal(Base):
 
         labels = list(map(str.strip, re.split(r'(?<!-)>', treepath)))
         labels = list(filter(None, labels))
+        dialog_layers = self.check_layers('wa-dialog')
 
         for row, label in enumerate(labels):
 
@@ -9233,6 +9234,8 @@ class WebappInternal(Base):
                                                 
                                                 if not success:
                                                     success = True if is_element_acessible() else False
+                                                    if not success and dialog_layers < self.check_layers('wa-dialog'):
+                                                        success = True
 
                                                 if success and right_click:
                                                     last_zindex = self.return_last_zindex()
@@ -9429,10 +9432,13 @@ class WebappInternal(Base):
         """
 
         container = self.get_current_container()
+        tr = []
 
         if self.webapp_shadowroot():
-           tr = self.driver.execute_script(f"return arguments[0].shadowRoot.querySelectorAll('wa-tree-node')", self.soup_to_selenium(container.select('wa-tree')[tree_number]))
-           return tr
+            bs_tree_node = container.select('wa-tree')
+            if bs_tree_node:
+                tr = self.driver.execute_script(f"return arguments[0].shadowRoot.querySelectorAll('wa-tree-node')", self.soup_to_selenium(bs_tree_node[tree_number]))
+            return tr
         else:
             tr = container.select("tr")
             tr_class = list(filter(lambda x: "class" in x.attrs, tr))

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -9234,6 +9234,8 @@ class WebappInternal(Base):
                                                 
                                                 if not success:
                                                     success = True if is_element_acessible() else False
+
+                                                    # If throug last click some dialog layers show up',
                                                     if not success and dialog_layers < self.check_layers('wa-dialog'):
                                                         success = True
 


### PR DESCRIPTION
Na suite FISA001 ao selecionar a opção "Processar Apuração da EFD Contribuições" no tree, é aberto um novo layer (wa-dialog) ocultando os itens na tree. Foi adicionada uma condição onde ao detectar essa nova camada, é entendido que o clique no item foi realizado com sucesso.

Também foi adicionada uma proteção no método treenode, pois ao tentar capturar uma tree e ela nao existir, retornava o erro list index out of range.