### PR TITLE
fix Wait processing filters blocked containers

### DIFF
--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -1517,6 +1517,14 @@ class Base(unittest.TestCase):
             return element
 
     def return_non_blocked_elements(self, elements, reverse):
+        '''Filter container without Blocker attribute
+
+        :param elements:
+        :type elements: BeautifulSoup Object or List of them
+        :param reverse:
+        :type reverse: Boolean
+        :return:
+        '''
 
         non_blocked_elements = list(filter(lambda x: hasattr(x, 'attr') and 'blocked' not in x.attrs, elements))
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -3731,7 +3731,7 @@ class WebappInternal(Base):
 
                 containers = self.zindex_sort(soup.select(container_selector), reverse=True)
 
-                if container_selector == 'wa-text-view':
+                if container_selector == 'wa-text-view' or optional_term and'wa-text-view' in optional_term:
                     return self.filter_label_element(term, container=soup, position=position, twebview=twebview) if self.filter_label_element(term, container=soup, position=position, twebview=twebview) else []
 
                 if self.base_container in container_selector:


### PR DESCRIPTION
Ao utilizar WaitProcessing em alguns casos, não era possivel a captura correta do texto desejado, pois alguns containers de processesamento vem com atributo "blocker".

A alteração cria uma condição para atender a um desvio ja previsto anteriormente.