### PR TITLE
remove switch to iframe while

### DIFF
--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -548,17 +548,15 @@ class Base(unittest.TestCase):
         if not self.config.poui:
             iframes = None
             filtered_iframe = None
-            endtime = time.time() + self.config.time_out
-            while time.time() < endtime and not iframes:
-                iframes = self.driver.find_elements(By.CSS_SELECTOR, '[class*="twebview"], [class*="dict-twebengine"]')
 
-                if iframes:
-                    filtered_iframe = self.filter_active_iframe(iframes)
-                else:
-                    self.driver.switch_to.default_content()
+            iframes = self.driver.find_elements(By.CSS_SELECTOR, '[class*="twebview"], [class*="dict-twebengine"]')
+            if iframes:
+                filtered_iframe = self.filter_active_iframe(iframes)
+            else:
+                self.driver.switch_to.default_content()
 
-                if filtered_iframe:
-                    self.driver.switch_to.frame(self.find_shadow_element('iframe', filtered_iframe)[0]) if self.webapp_shadowroot() else self.driver.switch_to.frame(filtered_iframe)
+            if filtered_iframe:
+                self.driver.switch_to.frame(self.find_shadow_element('iframe', filtered_iframe)[0]) if self.webapp_shadowroot() else self.driver.switch_to.frame(filtered_iframe)
 
 
     def filter_active_iframe(self, iframes):

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3191,7 +3191,7 @@ class PouiInternal(Base):
                     if has_index:
                         po_component_span = has_index
 
-            if len(po_component_span) >= position:
+            if po_component_span and len(po_component_span) >= position:
                 po_component_span = po_component_span[position]
                 return next(iter(po_component_span.find_parent('po-field-container')), None) if container else po_component_span
 


### PR DESCRIPTION
Foi entendido que o laço contido no metodo switch_to_iframe pode ser removido deixando a responsabilidade pelo fluxo das chamadas