### PR TITLE
fix bad_lines in pandas reading csv

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -10355,7 +10355,7 @@ class WebappInternal(Base):
         has_header = 'infer' if header else None
 
         if self.config.csv_path:
-            data = pd.read_csv(self.replace_slash(f"{self.config.csv_path}\\{csv_file}"), sep=delimiter, encoding='latin-1', on_bad_lines=False, header=has_header, index_col=False, dtype=str)
+            data = pd.read_csv(self.replace_slash(f"{self.config.csv_path}\\{csv_file}"), sep=delimiter, encoding='latin-1', on_bad_lines="warn", header=has_header, index_col=False, dtype=str)
             df = pd.DataFrame(data)
             df = df.dropna(axis=1, how='all')
 


### PR DESCRIPTION
Atualizado o parâmetro on_bad_lines de False (valor inválido nas versões atuais do pandas) para 'error' na chamada do pd.read_csv.


O uso de on_bad_lines=False era incorreto a partir do Pandas 1.3.0 e foi removido completamente em versões como 2.2.0.

'error' é o comportamento padrão e explicita que o parser deve lançar uma exceção caso encontre linhas malformadas no CSV.

Garante compatibilidade com versões modernas do Pandas e evita falhas silenciosas ou warnings ambíguos.