### PR TITLE
protect iframe switch

### DIFF
--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -541,19 +541,26 @@ class Base(unittest.TestCase):
 
     def switch_to_iframe(self):
         """
+        This method switches the Selenium driver to the active iframe.
+        It will try to find the iframe in current webdriver with the class "twebview" or "dict-twebengine" and switch to it.
         [Internal]
         :return:
         """
-
         if not self.config.poui:
             iframes = None
             filtered_iframe = None
+            tries = 0
 
-            iframes = self.driver.find_elements(By.CSS_SELECTOR, '[class*="twebview"], [class*="dict-twebengine"]')
-            if iframes:
-                filtered_iframe = self.filter_active_iframe(iframes)
-            else:
-                self.driver.switch_to.default_content()
+            while tries < 3 and not iframes:
+                # Try to find iframes with the class "twebview" or "dict-twebengine" in current webdriver
+                iframes = self.driver.find_elements(By.CSS_SELECTOR, '[class*="twebview"], [class*="dict-twebengine"]')
+
+                # If iframes are found, filter the active by zindex else switch to default content
+                if iframes:
+                    filtered_iframe = self.filter_active_iframe(iframes)
+                else:
+                    self.driver.switch_to.default_content()
+                tries += 1
 
             if filtered_iframe:
                 self.driver.switch_to.frame(self.find_shadow_element('iframe', filtered_iframe)[0]) if self.webapp_shadowroot() else self.driver.switch_to.frame(filtered_iframe)


### PR DESCRIPTION
Improved the switch_to_iframe method in base.py to make switching to the active iframe more robust.
Instead of a single attempt, the method now tries up to 3 times to find iframes with classes "twebview" or "dict-twebengine".
If no iframes are found, it switches to the default content. 
This change helps protect against failures when switching iframes, making the process more reliable.

TESTED:
test_FSMA001_001