### PR TITLE
remove wait to program search bar

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -307,17 +307,6 @@ class WebappInternal(Base):
 
             self.close_screen_before_menu()
 
-            if initial_program.lower() != 'sigacfg':
-                cget_term = '[name=cGet]'
-                endtime = time.time() + self.config.time_out
-                while time.time() < endtime and not self.element_exists(term=cget_term, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container="body"):
-                    logger().debug('Waiting menu screen after environment screen')
-                    time.sleep(10)
-
-                if time.time() > endtime:
-                    self.restart_counter + 1
-                    self.log_error(f"'Unable to load screen '{cget_term}' content.")
-
             if save_input:
                 self.set_log_info_config() if self.config.log_info_config else self.set_log_info()
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -307,6 +307,18 @@ class WebappInternal(Base):
 
             self.close_screen_before_menu()
 
+            if initial_program.lower() != 'sigacfg':
+                # wait to load the menu screen getting the cGet (search bar) or lateral menu element
+                menu_components = '[name=cGet], wa-menu'
+                endtime = time.time() + self.config.time_out
+                while time.time() < endtime and not self.element_exists(term=menu_components, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container="body"):
+                    logger().debug('Waiting menu screen after environment screen')
+                    time.sleep(10)
+
+                if time.time() > endtime:
+                    self.restart_counter + 1
+                    self.log_error(f"'Unable to load screen '{menu_components}' content.")
+
             if save_input:
                 self.set_log_info_config() if self.config.log_info_config else self.set_log_info()
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -307,18 +307,6 @@ class WebappInternal(Base):
 
             self.close_screen_before_menu()
 
-            if initial_program.lower() != 'sigacfg':
-                # wait to load the menu screen getting the cGet (search bar) or lateral menu element
-                menu_components = '[name=cGet], wa-menu'
-                endtime = time.time() + self.config.time_out
-                while time.time() < endtime and not self.element_exists(term=menu_components, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container="body"):
-                    logger().debug('Waiting menu screen after environment screen')
-                    time.sleep(10)
-
-                if time.time() > endtime:
-                    self.restart_counter + 1
-                    self.log_error(f"'Unable to load screen '{menu_components}' content.")
-
             if save_input:
                 self.set_log_info_config() if self.config.log_info_config else self.set_log_info()
 


### PR DESCRIPTION
Devido a possibilidade de personalização da tela removendo o campo de Pesquisar da home, foi removido o trecho onde aguardava este elemento dentro do Método  ´Setup´ deixando a responsabilidade se aguardar para os proximos métodos

Para testar :
Acessar via SIGACFG
Usuário > Senhas > Politicas > Usuário
Restrições de acesso, Acessos 
Desabilitar o Código : 138 - Habilitar opção de Executar (Ctrl+R)