### PR TITLE
hotfix cGet error in restart flow

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -1874,17 +1874,21 @@ class WebappInternal(Base):
 
         """
 
-        endtime = time.time() + self.config.time_out
+        endtime = time.time() + self.config.time_out /2
         while time.time() < endtime and self.check_layers('wa-dialog') > 1:
             if not self.webapp_shadowroot():
                 ActionChains(self.driver).key_down(Keys.ESCAPE).perform()
             elif self.check_layers('wa-dialog') > 1:
                 logger().info('Escape to menu')
-                ActionChains(self.driver).key_down(Keys.ESCAPE).perform()
+                ActionChains(self.driver).send_keys(Keys.ESCAPE).perform()
 
-            if self.check_layers('wa-dialog') > 1:
-                logger().info('Found layers after Escape to menu')
-                self.close_screen_before_menu()
+            if any([self.check_warning_screen(), self.check_coin_screen(), self.check_news_screen()]):
+                if self.check_layers('wa-dialog') > 1:
+                    logger().info('Found layers after Escape to menu')
+                    self.close_screen_before_menu()
+            # wait trasitions between screens to avoid errors in layers number
+            self.wait_element_timeout(term='wa-dialog', scrap_type=enum.ScrapType.CSS_SELECTOR,
+                                      position=2, timeout=6, main_container='body')
 
     def check_layers(self, term):
         """


### PR DESCRIPTION
Changes:

In WebappInternal.escape_to_main_menu, reduced the timeout for the escape loop from self.config.time_out to self.config.time_out / 2 for faster handling.

Improved the logic to handle screen layers: now, after sending ESCAPE, it checks for warning, coin, or news screens and only calls close_screen_before_menu if any are present and there are still multiple layers.

Added a wait (wait_element_timeout) for screen transitions to avoid errors related to the number of layers.

These changes make the restart/menu escape flow more robust, especially when handling the presence of modal dialogs or layered screens, reducing errors related to the cGet field not being found.

Suite tested:
PLSA498