### PR TITLE
Hotfix click combo selection error

### DIFF
--- a/tir/main.py
+++ b/tir/main.py
@@ -1658,7 +1658,7 @@ class Poui():
         """
         self.__poui.InputValue(field, value, position)
 
-    def ClickCombo(self, field='', value='', position=1):
+    def ClickCombo(self, field='', value='', position=1, second_value=''):
         """
         Clicks on the Combo of POUI component.
         https://po-ui.io/documentation/po-combo
@@ -1673,7 +1673,7 @@ class Poui():
         >>> oHelper.ClickCombo('Visão', 'Compras')
         :return:
         """
-        self.__poui.click_combo(field, value, position)
+        self.__poui.click_combo(field, value, position, second_value)
 
     def ClickSelect(self, field='', value='', position=1):
         """

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3884,10 +3884,10 @@ class PouiInternal(Base):
         while (not success and time.time() < endtime):
             po_combo = self.web_scrap(term='po-combo', scrap_type=enum.ScrapType.CSS_SELECTOR, position=position, main_container='body')
             if po_combo:
-                po_combo = next(iter(po_combo),None)
-                po_input = po_combo.find_next('input')
+                po_combo_filtred = next(iter(filter(lambda x: self.filter_label_element(field.strip(), x), po_combo)),None)
+                po_input = po_combo_filtred.find_next('input')
                 if po_input:
-                    self.open_input_combo(po_combo)
+                    self.open_input_combo(po_combo_filtred)
                     self.click_po_list_box(value)
                     current_value = self.get_web_value(self.soup_to_selenium(po_input, twebview=True))
                     success = re.sub(replace, '', current_value).lower() == re.sub(replace, '', value).lower()

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3885,6 +3885,7 @@ class PouiInternal(Base):
         endtime = time.time() + self.config.time_out
         while (not success and time.time() < endtime):
             po_combo = self.web_scrap(term='po-combo', scrap_type=enum.ScrapType.CSS_SELECTOR, position=position, main_container='body')
+            po_combo = list(filter(lambda x: self.element_is_displayed(x), po_combo))
             if po_combo:
                 po_combo_filtred = next(iter(filter(lambda x: self.filter_label_element(field.strip(), x), po_combo)),None)
                 po_input = po_combo_filtred.find_next('input')

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3859,7 +3859,7 @@ class PouiInternal(Base):
             self.log_error(f"CheckBox '{label}' doesn't found!")
 
 
-    def click_combo(self, field, value, position):
+    def click_combo(self, field, value, position, second_value):
         '''Select a value for list combo inputs.
 
         :param field: label of field
@@ -3868,6 +3868,8 @@ class PouiInternal(Base):
         :type : str
         :param position:
         :type : int
+        :param second_value: value below the principal value (after the ":")
+        :type : str
         :return:
         '''
 
@@ -3888,14 +3890,14 @@ class PouiInternal(Base):
                 po_input = po_combo_filtred.find_next('input')
                 if po_input:
                     self.open_input_combo(po_combo_filtred)
-                    self.click_po_list_box(value)
+                    self.click_po_list_box(value, second_value)
                     current_value = self.get_web_value(self.soup_to_selenium(po_input, twebview=True))
                     success = re.sub(replace, '', current_value).lower() == re.sub(replace, '', value).lower()
         if not success:
             self.log_error(f'Click on {value} of {field} Fail. Please Check')
 
 
-    def click_po_list_box(self, value):
+    def click_po_list_box(self, value, second_value):
         '''
         :param value: Value to select on po-list-box
         :type str

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3873,11 +3873,10 @@ class PouiInternal(Base):
         :return:
         '''
 
-        main_element = None
         success = None
         position -= 1
         current_value = None
-        replace = r'[\s,\.:]'
+        main_value = ''
 
         logger().info(f"Clicking on {field}")
         self.wait_element(term='po-combo')
@@ -3893,11 +3892,14 @@ class PouiInternal(Base):
                 po_input = po_combo_filtred.find_next('input')
                 if po_input:
                     po_input_sel = self.soup_to_selenium(po_input, twebview=True)
+
+                    main_value = self.get_web_value(self.soup_to_selenium(po_input, twebview=True))
                     self.open_input_combo(po_combo_filtred)
                     self.send_keys(po_input_sel, value if value else second_value)
-                    expected_value = self.click_po_list_box(value, second_value)
+                    self.click_po_list_box(value, second_value)
                     current_value = self.get_web_value(self.soup_to_selenium(po_input, twebview=True))
-                    success = re.sub(replace, '', current_value).lower() == re.sub(replace, '', expected_value).lower()
+                    success = current_value.strip().lower() == main_value.strip().lower() if value else True
+
         if not success:
             self.log_error(f'Click on {value} of {field} Fail. Please Check')
 
@@ -3912,10 +3914,8 @@ class PouiInternal(Base):
         '''
         orig_value = value
         orig_second_value = second_value
-        replace = r'[\s,\.:]'
-        value = re.sub(replace, '', value).strip().lower()
-        second_value = re.sub(replace, '', second_value).strip().lower()
-
+        value = value.strip().lower()
+        second_value = second_value.strip().lower()
 
         self.wait_element(term='po-listbox')
 
@@ -3928,8 +3928,6 @@ class PouiInternal(Base):
                 item_filtered_div = item_filtered.find_next('div')
                 self.scroll_to_element(self.soup_to_selenium(item_filtered_div, twebview=True))
                 self.click(self.soup_to_selenium(item_filtered_div, twebview=True))
-
-                return json.loads(item_filtered.get('data-item-list')).get('label') if not value else orig_value
             else:
                 self.log_error(f'Item list {orig_value if orig_value else orig_second_value} not found')
 

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3892,7 +3892,11 @@ class PouiInternal(Base):
                     self.open_input_combo(po_combo_filtred)
                     self.click_po_list_box(value, second_value)
                     current_value = self.get_web_value(self.soup_to_selenium(po_input, twebview=True))
-                    # success = re.sub(replace, '', current_value).lower() == re.sub(replace, '', value).lower()
+                    if value:
+                        success = re.sub(replace, '', current_value).lower() == re.sub(replace, '', value).lower()
+                    else:
+                        # Implementar uma lógica de validar apenas com o second_value
+                        success = True
         if not success:
             self.log_error(f'Click on {value} of {field} Fail. Please Check')
 

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3889,14 +3889,12 @@ class PouiInternal(Base):
                 po_combo_filtred = next(iter(filter(lambda x: self.filter_label_element(field.strip(), x), po_combo)),None)
                 po_input = po_combo_filtred.find_next('input')
                 if po_input:
+                    po_input_sel = self.wait_soup_to_selenium(po_input, twebview=True)
                     self.open_input_combo(po_combo_filtred)
-                    self.click_po_list_box(value, second_value)
+                    self.send_keys(po_input_sel, value if value else second_value)
+                    expected_value = self.click_po_list_box(value, second_value)
                     current_value = self.get_web_value(self.soup_to_selenium(po_input, twebview=True))
-                    if value:
-                        success = re.sub(replace, '', current_value).lower() == re.sub(replace, '', value).lower()
-                    else:
-                        # Implementar uma lógica de validar apenas com o second_value
-                        success = True
+                    success = re.sub(replace, '', current_value).lower() == re.sub(replace, '', expected_value).lower()
         if not success:
             self.log_error(f'Click on {value} of {field} Fail. Please Check')
 
@@ -3940,8 +3938,12 @@ class PouiInternal(Base):
                 item_filtered_div = item_filtered.find_next('div')
                 self.scroll_to_element(self.soup_to_selenium(item_filtered_div, twebview=True))
                 self.click(self.soup_to_selenium(item_filtered_div, twebview=True))
+
+                return json.loads(item_filtered.get('data-item-list')).get('label') if not value else orig_value
             else:
                 self.log_error(f'{orig_value if orig_value else orig_second_value} not found')
+
+        return orig_value
 
 
     def open_input_combo(self, po_combo):


### PR DESCRIPTION
Após ser relato o erro na task #CA-10388 do Ryver, que a função ClickCombo do PO UI não estava encontrando o valor correto na lista, eu identifiquei que o erro acontecia por que no caso relato havia um "valor principal" e um "valor secundário". 
Desta forma adicionei o parâmetro que possibilita fazer a busca por um dos valores ou por ambos.
Após as minhas alterações o Leandro fez algumas melhorias de proteção no código.