### PR TITLE
Function ClickGridCell index break

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -7154,7 +7154,7 @@ class WebappInternal(Base):
                                 columns = rows[row_number].select("td")
 
                     if columns:
-                        if column_name in headers[grid_number]:
+                        if len(headers) >= grid_number and column_name in headers[grid_number]:
                             column_number = headers[grid_number][column_name]
                             if self.webapp_shadowroot():
                                 column_element = lambda: columns[column_number]

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -7154,7 +7154,7 @@ class WebappInternal(Base):
                                 columns = rows[row_number].select("td")
 
                     if columns:
-                        if len(headers) >= grid_number and column_name in headers[grid_number]:
+                        if len(headers) > grid_number and column_name in headers[grid_number]:
                             column_number = headers[grid_number][column_name]
                             if self.webapp_shadowroot():
                                 column_element = lambda: columns[column_number]


### PR DESCRIPTION
Após a análise do erro relatado na task #CA-10423 (Ryver), identifiquei que a função `ClickGridCell`, nessa caso em específico, estava lançando a exceção:

`
IndexError: list index out of range.
`

Para resolver o problema, adicionei uma **verificação que garante que o índice está dentro dos limites do array antes de acessá-lo**, evitando o erro.