### PR TITLE
Commit changes in ClickCheckBox

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -8828,8 +8828,9 @@ class WebappInternal(Base):
             while time.time() < endtime and not success:
                 label_box = self.get_checkbox_label(label_box_name, position)
                 if label_box:
-                    checked_status =lambda: (hasattr(self.get_checkbox_label(label_box_name, position), 'attrs') and
-                                             'checked' in self.get_checkbox_label(label_box_name, position).attrs)
+                    checked_status =lambda: ((hasattr(self.get_checkbox_label(label_box_name, position), 'attrs') and
+                                             'checked' in self.get_checkbox_label(label_box_name, position).attrs)  or \
+                                             (self.soup_to_selenium(label_box).get_attribute('checked')))
                     if 'tcheckbox' or 'dict-tcheckbox' in label_box.get_attribute_list('class'):
                         label_box_element  = lambda: self.soup_to_selenium(label_box)
                         check_before_click = checked_status()


### PR DESCRIPTION
# Description

A suite PLSWIZARD não estava gerando log no portal e a mesma falhava devido a um erro no método ClickCheckBox. O checked_status não consegue encontrar o atributo checked depois que fez o clique no método. 

Para corrigir além de usar o checked_status foi adicionado um or para transformar em selenium a labelbox e com isso verificar se o atributo checked existe.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Hotfix - Bug fix (non-breaking change which fixes an issue) 


# How Has This Been Tested?

Suite PLSWIZARD

- [ ] Manual
- [ ] SmartTest

**Test Configuration**:
* Add your description.
