### PR TITLE
Hotfix CheckHelp modal close

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -6610,7 +6610,7 @@ class WebappInternal(Base):
                                                     self.send_keys(selenium_input(), Keys.ENTER)
 
                                     elif lenfield == len(field[1]) and self.get_current_container().attrs[
-                                        'id'] != container_id:
+                                        'id'] != container_id and not modal_open:
                                         try:
                                             self.send_keys(selenium_input(), Keys.ENTER)
                                         except:

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -9966,12 +9966,13 @@ class WebappInternal(Base):
         text_solution_extracted = ""
         text_extracted = ""
         regex = r"(<[^>]*>)"
+        closed_modal = False
 
         if not button:
             button = self.get_single_button().text
 
         endtime = time.time() + self.config.time_out
-        while(time.time() < endtime and not text_extracted):
+        while(time.time() < endtime and (not text_extracted or not closed_modal)):
 
             logger().info(f"Checking Help on screen: {text}")
             # self.wait_element_timeout(term=text, scrap_type=enum.ScrapType.MIXED, timeout=2.5, step=0.5, optional_term=".tsay", check_error=False)
@@ -10024,10 +10025,11 @@ class WebappInternal(Base):
             if text_extracted:
                 self.check_text_container(text, text_extracted, container_text, verbosity)
                 self.SetButton(button, check_error=False)
-                self.wait_element(term=text, scrap_type=enum.ScrapType.MIXED,
-                 optional_term=label_term, presence=False, main_container = self.containers_selectors["AllContainers"], check_error=False)
+                closed_modal = not self.wait_element_timeout(term=text, scrap_type=enum.ScrapType.MIXED, timeout=2, step=0.5,
+                                                            optional_term=label_term, main_container=self.containers_selectors["AllContainers"], 
+                                                            check_error=False)
 
-        if not text_extracted:
+        if not text_extracted or not closed_modal:
             self.log_error(f"Couldn't find: '{text}', text on display window is: '{container_text}'")
 
     def check_text_container(self, text_user, text_extracted, container_text, verbosity):


### PR DESCRIPTION
Corrige problema de abertura duplicada do modal de help no WebApp versão 10.1.2.
Ocorre que, durante a inserção do valor no input, uma função enviava a tecla Enter mesmo com o modal de help ainda aberto, ocasionando a validação duplicada e a reabertura do modal.
Ajustes realizados:

- Na função de inserção do valor, o Enter só é enviado se o modal já tiver sido fechado.
- Na função de verificação do help, após clicar em fechar, é feita a checagem contínua até que o modal realmente não esteja mais visível ou até atingir o time-out.