### PR TITLE
skip program screen when not found

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -403,7 +403,7 @@ class WebappInternal(Base):
         >>> self.program_screen("SIGAADV", "MYENVIRONMENT")
         """
 
-        wizard_screen = []
+        program_screem = []
 
         if not environment:
             environment = self.config.environment
@@ -415,13 +415,14 @@ class WebappInternal(Base):
         self.config.poui_login = poui
         endtime = time.time() + 10
 
-        while time.time() < endtime and not wizard_screen:
-            wizard_screen = self.web_scrap(term=self.language.next.replace(">>", "").strip(), scrap_type=enum.ScrapType.TEXT,
-                                     optional_term=".wa-button, wa-text-view",
+        while time.time() < endtime and not program_screem:
+            start_program_term = '#selectStartProg'
+            program_screem =  self.web_scrap(term=start_program_term, scrap_type=enum.ScrapType.CSS_SELECTOR,
                                      main_container=self.containers_selectors["AllContainers"],
                                      check_help=False, check_error=False)
 
-        if not wizard_screen:
+
+        if program_screem:
             self.filling_initial_program(initial_program)
             self.filling_server_environment(environment)
 


### PR DESCRIPTION
In the program_screen method of WebappInternal, replaced the variable wizard_screen with program_screem for clarity.
Changed the logic to search for the program screen using a CSS selector (#selectStartProg) instead of a text-based search.
Now, the method only proceeds to fill the initial program and environment if the program screen is found (if program_screem:), otherwise it skips these steps.

Suite tested: GRRWIZARD

Task Related:
https://jiraproducao.totvs.com.br/browse/ENGPROCA-9635