### PR TITLE
Change the order of the wait_blocker function call

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -10442,6 +10442,8 @@ class WebappInternal(Base):
         :return: True if there was a change in the object
         """
 
+        self.wait_blocker()
+
         twebview = True if self.config.poui_login else False
 
         soup_before_event = self.get_current_DOM(twebview=twebview)
@@ -10457,7 +10459,6 @@ class WebappInternal(Base):
             classes_before = self.get_selenium_attribute(element(), 'class')
             classes_after = classes_before
 
-        self.wait_blocker()
         soup_select = None
 
         main_click_type = click_type
@@ -10480,6 +10481,8 @@ class WebappInternal(Base):
                     action(click_type=enum.ClickType(click_type), element=element())
                 elif action:
                     action()
+                    
+                time.sleep(1)
 
                 if soup_select:
                     soup_after_event = soup_select
@@ -10500,7 +10503,6 @@ class WebappInternal(Base):
 
                 if not wait_change:
                     return True
-                time.sleep(1)
 
         except Exception as e:
             if self.config.smart_test or self.config.debug_log:


### PR DESCRIPTION
# Description

O fluxo da função `send_action` anteriormente era:

-> Recuperar a DOM antes do clique.
-> Aguardar o blocker.
-> Realizar a ação.
-> Recuperar a DOM depois do clique .
-> Aguarda um segundo.
-> Se as DOMs recuperadas estiverem diferentes, o clique é considerado válido e o script segue. Se estiverem iguais, é feita uma nova tentativa com outro método.

O problema é que a primeira DOM era recuperada antes de aguardar o blocker, ou seja, ela ainda continha os atributos do blocker. Dessa forma, se a ação não causasse nenhuma alteração na DOM, a verificação passava de qualquer jeito, já que após aguardar o blocker a DOM não teria mais os atributos dele — e, nesse caso, nenhuma nova tentativa da ação era feita.

Para corrigir isso, inverti a ordem das funções, passando a aguardar o blocker antes de recuperar a primeira DOM. O fluxo ficou assim:

-> Aguardar o blocker.
-> Recuperar a DOM antes do clique.
-> Realizar a ação.
-> Aguarda um segundo.
-> Recuperar a DOM depois do clique .
-> Se as DOMs recuperadas estiverem diferentes, o clique é considerado válido e o script segue. Se estiverem iguais, é feita uma nova tentativa com outro método.

Além disso, também mudei a ordem do `sleep`, que agora fica entre a ação e a recuperação da DOM, para garantir que a ação tenha tempo de ser processada — ou pelo menos parte dela — antes da nova captura da DOM.

## Type of change

- [X] Hotfix - Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Esta alteração deve surtir efeito nas execuções da 2510 no SmarTest, onde alguns cliques não estão sendo efetivos na primeira tentativa. Por conta do comportamento descrito anteriormente, não é feita uma segunda tentativa e, consequentemente, a próxima ação do script dá erro, já que a ação anterior não foi realizada.

Suíte usada nesse caso: ATFA125 (Os casos ocorrem na função `SetButton("Ok")` que são executados após a função `SetValue("Hist. Solic.", "XX")`).

- [ ] Manual
- [X] SmartTest