### PR TITLE
fix SetValue filling wrong input

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -3037,14 +3037,16 @@ class WebappInternal(Base):
                             tries = 0
                             try_counter = 1
                             while(tries < 3):
+                                self.click(input_field(), enum.ClickType.SELENIUM)
                                 self.set_element_focus(input_field())
                                 self.wait_until_to( expected_condition = "element_to_be_clickable", element = element, locator = By.XPATH, timeout=True)
                                 self.try_send_keys(input_field, main_value, try_counter)
+                                self.set_element_focus(input_field())
                                 current_number_value = self.get_web_value(input_field())
                                 if re.sub('[\s,\.:]', '', self.remove_mask(current_number_value, valtype)).strip() == re.sub('[\s,\.:]', '', main_value).strip():
                                     break
-                                tries+=1
-                                try_counter+=1
+                                tries += 1
+                                try_counter += 1
 
 
                         if self.check_mask(input_field()):


### PR DESCRIPTION
Changes Made
The fix addresses a problem where the SetValue method was filling the wrong input field. The changes include:

Added explicit click action - Added self.click(input_field(), enum.ClickType.SELENIUM) before setting focus to ensure the correct field is selected

Enhanced focus management - Added an additional self.set_element_focus(input_field()) call after sending keys to maintain proper focus on the target element

Improved retry mechanism - The existing retry loop (tries < 3) now has better element interaction by ensuring the field is properly clicked and focused before attempting to input values

Suite Error:
MATA250EST - CT01
        self.oHelper.SetValue('Quantidade',"5,00")

In some cases when filling the Quantity field, the loop action gets lost and performs the filling twice, with one of them going to the wrong field
