### PR TITLE
Add space treatment in conditions

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -9101,7 +9101,7 @@ class WebappInternal(Base):
                         filter(lambda x: not x.find_parents(class_='hidden'), tree_node))
 
                 elements = list(
-                    filter(lambda x: label_filtered in x.text.lower().strip() and self.element_is_displayed(x),
+                    filter(lambda x: label_filtered in re.sub(r'[ ]{2,}', ' ', x.text).lower().strip() and self.element_is_displayed(x),
                            tree_node_filtered))
 
                 if elements:
@@ -9353,7 +9353,7 @@ class WebappInternal(Base):
         else:
             treenode_selected = list(filter(lambda x: "selected" in x.attrs['class'], ttreenode))
 
-        return next(iter(list(filter(lambda x: label_filtered == x.text.lower().strip(), treenode_selected))), None)
+        return next(iter(list(filter(lambda x: label_filtered == re.sub(r'[ ]{2,}', ' ', x.text).lower().strip(), treenode_selected))), None)
 
     def treenode(self, tree_number=0):
         """


### PR DESCRIPTION
# Description

Na função ClickTree, o valor passado por parâmetro é tratado substituindo dois espaços ("  ") por apenas um (" "), porém na hora de procurar o elemento, na comparação do valor do elemento com o parâmetro, não é realizado o tratamento do espaço no valor do elemento.
Portanto quando era necessário passar por parâmetro para a função um valor com dois espaços, da erro.

Com isso realizei o ajuste, para que a comparação tenha o mesmo tratamento dos dois lados.

Verifiquei que além da suíte relatada pelo usuário no ryver (GCPA200), há ainda outras suítes que estão apresentando o mesmo erro com o mesmo cenário.
Fiz o teste em todas as suítes que apresentam esse erro, e de fato, sem a minha alteração deram erro e com a minha alteração passava.

Suítes com este erro:
- FATA070
- GCPA200
- MATA410_002
- MATA120
- TRKXFUN

## Type of change

Please delete options that are not relevant.
- [X] Hotfix - Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Executando as suítes listadas na descrição com a release 2510.

- [ ] Manual
- [X] SmartTest

