### PR TITLE
Add click verification

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -2281,6 +2281,9 @@ class WebappInternal(Base):
         :type: selenium.webdriver.remote.webelement.WebElement
         :return: True if the parent div has the 'selected' class, False otherwise.
         :rtype: bool
+
+        """
+        
         return True if 'selected' in element.get_attribute('class') else False
 
     def search_browse_bcolumn(self, search_column, search_elements, index=False):

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -2151,17 +2151,20 @@ class WebappInternal(Base):
                             filter(lambda x: not re.search(r"(\.\.)$", x.next.text), radio_menu))
 
                     if tradiobuttonitens_not_ends_dots:
-                        if self.webapp_shadowroot():
-                            radio = next(iter(list(filter(lambda x: search_key in re.sub(r"(\s)?(\.+$)?", '', x.text).lower() , tradiobuttonitens_not_ends_dots))), None)
-                            if radio:
-                                radio.find_element(By.TAG_NAME, 'input').click()
-                                success = True
-                        else:
-                            radio = next(iter(list(filter(lambda x: search_key in re.sub(r"\.+$", '', x.next.text.strip()).lower() , tradiobuttonitens_not_ends_dots))), None)
-                            if radio:
-                                self.wait_until_to( expected_condition = "element_to_be_clickable", element = radio, locator = By.XPATH )
-                                self.click(self.soup_to_selenium(radio))
-                                success = True
+                        try_click = 0
+                        while not success and try_click < 3:
+                            if self.webapp_shadowroot():
+                                radio = next(iter(list(filter(lambda x: search_key in re.sub(r"(\s)?(\.+$)?", '', x.text).lower() , tradiobuttonitens_not_ends_dots))), None)
+                                if radio:
+                                    radio.find_element(By.TAG_NAME, 'input').click()
+                                    success = self.check_input_radio(radio)
+                            else:
+                                radio = next(iter(list(filter(lambda x: search_key in re.sub(r"\.+$", '', x.text.strip()).lower() , tradiobuttonitens_not_ends_dots))), None)
+                                if radio:
+                                    self.wait_until_to( expected_condition = "element_to_be_clickable", element = radio, locator = By.XPATH )
+                                    self.click(self.soup_to_selenium(radio))
+                                    success = self.check_input_radio(radio)
+                            try_click += 1
 
                     if tradiobuttonitens_ends_dots and not success and self.config.initial_program.lower() != "sigaadv":
                         for element in tradiobuttonitens_ends_dots:
@@ -2270,7 +2273,18 @@ class WebappInternal(Base):
             self.send_keys(self.soup_to_selenium(bs_radio_menu), Keys.ESCAPE)
             time.sleep(1)
 
-    def search_browse_column(self, search_column, search_elements, index=False):
+    def check_input_radio(self, element):
+        """
+        Checks if the div (parent) containing the radio input has the 'selected' class
+
+        :param element: selenium object of the input's parent div
+        :type: selenium.webdriver.remote.webelement.WebElement
+
+        """
+
+        return True if 'selected' in element.get_attribute('class') else False
+
+    def search_browse_bcolumn(self, search_column, search_elements, index=False):
         """
         [Internal]
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -2279,9 +2279,8 @@ class WebappInternal(Base):
 
         :param element: selenium object of the input's parent div
         :type: selenium.webdriver.remote.webelement.WebElement
-
-        """
-
+        :return: True if the parent div has the 'selected' class, False otherwise.
+        :rtype: bool
         return True if 'selected' in element.get_attribute('class') else False
 
     def search_browse_bcolumn(self, search_column, search_elements, index=False):


### PR DESCRIPTION
Após o relato de um usuário no Gitter informando que um único clique no input do tipo radio não estava sendo suficiente para selecioná-lo ao utilizar a função SearchBrowse, adicionei um loop que realiza até três tentativas de clique. Caso o elemento seja selecionado com sucesso, o loop é interrompido imediatamente, assim não afetando o comportamento de como era antes.