### PR TITLE
Hotfix/click tree

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -9098,7 +9098,7 @@ class WebappInternal(Base):
                 # Filter out hidden nodes
                 non_hidden_tree_nodes = list(filter(lambda x: not x.get_attribute('hidden'), tree_node))
 
-                # Filter node elements matching the label displayeds
+                # Filter node elements matching the label displayed
                 filtered_nodes = list(
                     filter(lambda x: label_filtered in re.sub(r'[ ]{2,}', ' ', x.text).lower().strip() and self.element_is_displayed(x),
                            non_hidden_tree_nodes))

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -9280,7 +9280,7 @@ class WebappInternal(Base):
         else:
             if self.webapp_shadowroot():
                 tree_selected = self.execute_js_selector('span[class~=toggler]', treenode_selected, get_all=False)
-                if self.execute_js_selector('span[class~=toggler]', treenode_selected, get_all=False):
+                if tree_selected:
                     return not treenode_selected.get_attribute('closed')
             else:
                 tree_selected = next(iter(list(filter(lambda x: label_filtered == x.text.lower().strip(), treenode_selected))), None)

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -9098,7 +9098,7 @@ class WebappInternal(Base):
                 # Filter out hidden nodes
                 non_hidden_tree_nodes = list(filter(lambda x: not x.get_attribute('hidden'), tree_node))
 
-                # Filter node elements matching the label displayeds
+                # Filter node elements matching the label displayed
                 filtred_nodes = list(
                     filter(lambda x: label_filtered in re.sub(r'[ ]{2,}', ' ', x.text).lower().strip() and self.element_is_displayed(x),
                            non_hidden_tree_nodes))

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -9099,23 +9099,23 @@ class WebappInternal(Base):
                 non_hidden_tree_nodes = list(filter(lambda x: not x.get_attribute('hidden'), tree_node))
 
                 # Filter node elements matching the label displayeds
-                filtred_nodes = list(
+                filtered_nodes = list(
                     filter(lambda x: label_filtered in re.sub(r'[ ]{2,}', ' ', x.text).lower().strip() and self.element_is_displayed(x),
                            non_hidden_tree_nodes))
 
-                if filtred_nodes:
+                if filtered_nodes:
                     if position:
-                        elements = filtred_nodes[position] if len(filtred_nodes) >= position + 1 else next(iter(filtred_nodes))
+                        elements = filtered_nodes[position] if len(filtered_nodes) >= position + 1 else next(iter(filtered_nodes))
                         if hierarchy:
                             elements = elements if elements.attrs['hierarchy'].startswith(hierarchy) and elements.attrs[
                                 'hierarchy'] != hierarchy else None
                     else:
-                        elements = list(filter(lambda x: self.element_is_displayed(x), filtred_nodes))
+                        elements = list(filter(lambda x: self.element_is_displayed(x), filtered_nodes))
 
                         if hierarchy:
                             if not self.webapp_shadowroot():
                                 elements = list(filter(lambda x: x.attrs['hierarchy'].startswith(hierarchy) and x.attrs[
-                                    'hierarchy'] != hierarchy, filtred_nodes))
+                                    'hierarchy'] != hierarchy, filtered_nodes))
 
                     for element in elements:
                         if not success:


### PR DESCRIPTION
Refactors and hardens tree navigation logic in click_tree and related helpers:

Added detailed debug logging at each step (label processing, node search, node found).
- Normalizes label text (collapsing multiple spaces) and splits path with a regex excluding hyphenated cases.
- Introduces clearer determination of last path item and success tracking.
 - Replaces scattered direct driver.execute_script calls with centralized execute_js_selector for shadow DOM queries (e.g. .toggler, .lastchild, .data, label, .icon, wa-tree-node).
- Filters out hidden tree nodes before matching; improves hierarchy filtering when position and hierarchy are in play.
- Simplifies element click resolution: always uses a lambda returning the selenium element; removes separate shadow/non-shadow lambda branches.
- Improves expansion logic (retries up to 3 clicks when node is still closed) using consolidated selectors.
- Adds safeguards and clearer success criteria when right-clicking or expanding nodes.
- Enhances find_tree_bs with logging and reuse of execute_js_selector.

Impact / Rationale
- More resilient against hidden/inactive nodes.
- Cleaner, less duplicated shadow vs non-shadow handling.
- Better debuggability via granular logs.
- Lower risk of stale element or mismatched hierarchy errors.


Suite:
MATA120:
local- ok
smarttest- error