### PR TITLE
Hotfix/click icon selector

### DIFF
--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -2491,7 +2491,7 @@ class PouiInternal(Base):
             if type(element) == Tag:
                 element = self.soup_to_selenium(element)
             if self.execute_js_selector('button', element):
-                element_function = lambda: next(iter(self.execute_js_selector('button', element)))
+                element_function = lambda: self.execute_js_selector('button', element , get_all = False)
             elif element:
                 element_function = lambda: element
             if not element:

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -27,6 +27,18 @@ from tir.technologies.core.logging_config import logger
 import pathlib
 import json
 
+def count_time(func):
+    """
+    Decorator to count the time spent in a function.
+    """
+    def wrapper(*args, **kwargs):
+        starttime = time.time()
+        result = func(*args, **kwargs)
+        endtime = time.time()
+        logger().debug(f"Time spent in {func.__name__}: {endtime - starttime}")
+        return result
+    return wrapper
+
 class PouiInternal(Base):
     """
     Internal implementation of POUI class.
@@ -3711,12 +3723,15 @@ class PouiInternal(Base):
 
         term = 'po-icon'
 
+        if class_name:
+            term += ' i.' + '.'.join(class_name.split(' '))
+
         self.wait_element(term=term, scrap_type=enum.ScrapType.CSS_SELECTOR)
+
+        logger().info(f"Clicking on Icon: {label or class_name}")
 
         endtime = time.time() + self.config.time_out
         while time.time() < endtime and not element:
-
-            logger().info("Clicking on Icon")
 
             po_icon = self.web_scrap(term=term, scrap_type=enum.ScrapType.CSS_SELECTOR,
                                      main_container='body')
@@ -3750,7 +3765,7 @@ class PouiInternal(Base):
         """
 
         icon_classes = list(filter(lambda x: 
-            class_name.lower().strip() in ' '.join(x.select('i')[0].get('class', [])),
+            class_name.lower().strip() in ' '.join(x.get('class', [])),
                                      elements))
         if icon_classes:
             return icon_classes[position]

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -69,7 +69,7 @@ class PouiInternal(Base):
 
         self.containers_selectors = {
             "SetButton" : ".tmodaldialog,.ui-dialog",
-            "GetCurrentContainer": ".tmodaldialog",
+            "GetCurrentContainer": ".tmodaldialog, wa-dialog, wa-message-box",
             "AllContainers": "body,.tmodaldialog,.ui-dialog",
             "ClickImage": ".tmodaldialog",
             "BlockerContainers": ".tmodaldialog,.ui-dialog",
@@ -3709,7 +3709,7 @@ class PouiInternal(Base):
         position -= 1
         element = None
 
-        term = '[class*="po-icon"]'
+        term = 'po-icon'
 
         self.wait_element(term=term, scrap_type=enum.ScrapType.CSS_SELECTOR)
 
@@ -3725,10 +3725,10 @@ class PouiInternal(Base):
                 po_icon_filtered = list(filter(lambda x: self.element_is_displayed(x), po_icon))
 
                 if label and class_name:
-                    class_element = self.return_icon_class(class_name, po_icon_filtered)
+                    class_element = self.return_icon_class(class_name, po_icon_filtered, position)
                     element = class_element if self.check_element_tooltip(class_element, label, contains=True) else None
                 elif class_name:
-                    element = self.return_icon_class(class_name, po_icon_filtered)
+                    element = self.return_icon_class(class_name, po_icon_filtered, position)
                 else:
                     element = self.filter_by_tooltip_value(po_icon_filtered, label)
 
@@ -3741,7 +3741,7 @@ class PouiInternal(Base):
         if not element:
             self.log_error(f"Element '{element}' doesn't found!")
 
-    def return_icon_class(self, class_name, elements):
+    def return_icon_class(self, class_name, elements, position):
         """
 
         :param class_name: The POUI class name for icon
@@ -3751,11 +3751,11 @@ class PouiInternal(Base):
         :return: filtered bs4 object
         """
 
-        icon_classes = list(filter(lambda x: any(
-            class_name.lower().strip() == f'po-icon {attr.lower().strip()}' for attr in x.attrs.get('class', [])),
+        icon_classes = list(filter(lambda x: 
+            class_name.lower().strip() in ' '.join(x.select('i')[0].get('class', [])),
                                      elements))
         if icon_classes:
-            return next(iter(icon_classes))
+            return icon_classes[position]
 
     def click_avatar(self, position):
         """

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3733,8 +3733,6 @@ class PouiInternal(Base):
                     element = self.filter_by_tooltip_value(po_icon_filtered, label)
 
                 if element:
-                    if position > 0 and position >= len(element):
-                        element = element[position]
 
                     self.poui_click(element)
 


### PR DESCRIPTION
Alterei o seletor do po-icon para que pegue todos os ícones através da tag "po-icon", antes não estava retornando todos os ícones da página.

Além de ajustar o seletor, como o único critério de filtrar os ícones é pela classe, eu já ajustei isto no seletor para que os ícones sejam filtrados no momento do scrap.

Atualizei as funções de identificar o ícone pelo tooltip como estava no webapp.