### PR TITLE
fix to coverage by issue

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -3574,6 +3574,7 @@ class WebappInternal(Base):
         new_modal = False
         coverage_exceed_timeout = False
         start_program_term = '#selectStartProg'
+        program_screen = None
             
         endtime = time.time() + timeout
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -3573,6 +3573,7 @@ class WebappInternal(Base):
         element = None
         new_modal = False
         coverage_exceed_timeout = False
+        start_program_term = '#selectStartProg'
             
         endtime = time.time() + timeout
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -3594,16 +3594,25 @@ class WebappInternal(Base):
                 ActionChains(self.driver).key_down(Keys.CONTROL).send_keys('q').key_up(Keys.CONTROL).perform()
                 element = self.wait_element_timeout(term=self.language.finish, scrap_type=enum.ScrapType.MIXED,
                                                     optional_term=optional_term, timeout=5, step=1, main_container="body", check_error=False)
-                
+                if element:
+                    current_layers = self.check_layers('wa-dialog')
+                    self.SetButton(self.language.finish)
+
             if element and not new_modal:
-                current_layers = self.check_layers('wa-dialog')
-                self.SetButton(self.language.finish)
                 new_modal = current_layers + 1 == self.check_layers('wa-dialog')
+                program_screen = self.wait_element_timeout(term=start_program_term,
+                                                           scrap_type=enum.ScrapType.CSS_SELECTOR, timeout=5,
+                                                           main_container=self.containers_selectors["AllContainers"],
+                                                           check_error=False)
                 logger().debug("Waiting for coverage to finish.")
 
             if new_modal:
                 coverage_finished = current_layers >= self.check_layers('wa-dialog')
-            
+
+            if not new_modal and program_screen:
+                logger().debug("Coverage Screen not found, but fineshed")
+                coverage_finished = True
+
             if coverage_finished:
                 logger().debug("Coverage finished.")
                 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -3576,7 +3576,7 @@ class WebappInternal(Base):
             
         endtime = time.time() + timeout
 
-        logger().debug("Startin coverage.")
+        logger().debug("Starting coverage.")
 
         while not coverage_finished:
 
@@ -3610,13 +3610,14 @@ class WebappInternal(Base):
                 coverage_finished = current_layers >= self.check_layers('wa-dialog')
 
             if not new_modal and program_screen:
-                logger().debug("Coverage Screen not found, but fineshed")
+                logger().debug("Coverage Screen not found, finishing coverage.")
                 coverage_finished = True
 
             if coverage_finished:
                 logger().debug("Coverage finished.")
                 
             time.sleep(1)
+
 
     def click_button_finish(self, click_counter=None):
         """


### PR DESCRIPTION
Devido a velocidade de abertura da tela de processamento da cobertura no novo modelo por issue, a validação da ocorrencia ficava travada, foi criado uma condição onde é validada, dada a transição ao fazer o refresh para tela inicial.
