### PR TITLE
Feature/file comparison

### DIFF
--- a/tir/main.py
+++ b/tir/main.py
@@ -2202,7 +2202,7 @@ class Poui():
             # Using absolute paths
             >>> oHelper.FileComparison(r'C:/example/file1.txt', r'D:/temp/file2.txt')
             # Using current script directory for both files
-            >>> oHelper.FileComparison(self.oHelper.GetCurrentPath() + 'expected.txt', self.oHelper.GetCurrentPath() + 'generated.txt')
+            >>> oHelper.FileComparison(oHelper.GetCurrentPath() + 'expected.txt', oHelper.GetCurrentPath() + 'generated.txt')
         """
         return self.__webapp.file_comparison(base_file=base_file, current_file=current_file)
     

--- a/tir/main.py
+++ b/tir/main.py
@@ -1573,24 +1573,18 @@ class Webapp():
     def FileComparison(self, base_file:str, current_file:str) -> bool:
         """Compares two files and returns True if they are byte‑for‑byte identical.
 
-        Path resolution:
-        1. If you pass only the file name (no directory), it will be looked up inside the folder defined by
-           "BaselinePath" in config.json.
-        2. If you pass a full path (absolute or relative including a directory component), that path is used
-           as-is and is NOT concatenated with "BaselinePath".
+        Attention to the use of file paths:
+            1. Bare file name (no directory) -> looked up under "BaselinePath" (or cwd if BaselinePath missing/empty).
+            2. Path with a directory component (absolute or relative) -> used as provided; no BaselinePath prefix.
 
-        Attention (config.json):
-        - Ensure the "BaselinePath" key is declared and points to the baseline folder of protheus_data.
-          Example:
-              "BaselinePath": "C:/TOTVS/Protheus/bra/12.1.2510/Protheus_data/baseline"
+        Config note:
+            - Define "BaselinePath" (e.g. "BaselinePath": "C:/TOTVS/Protheus/.../baseline") to avoid unintended
+              fallback to the current working directory and potential "file not found" errors.
 
         Files in the script root:
-        - If the file you want to compare is located in the test script root folder, use the `GetCurrentPath()` 
-          function to obtain that path in a portable way (local execution and SmartTest).
-          Example:
-              base = GetCurrentPath() + 'esperado.txt'
-              current = GetCurrentPath() + 'gerado.txt'
-              oHelper.FileComparison(base, current)
+            - If the file you want to compare is located in the test script root folder, use the `GetCurrentPath()`
+              function to obtain that path in a portable way (local execution and SmartTest). `GetCurrentPath()`
+              already returns a path with a trailing separator.
 
         Return values:
             True  -> identical content
@@ -1598,8 +1592,12 @@ class Webapp():
             (If a file does not exist the framework logs an error and the test fails.)
 
         Usage examples:
+            # Using BaselinePath (or cwd fallback if BaselinePath is empty)
             >>> oHelper.FileComparison('file1.txt', 'file2.txt')
-            >>> oHelper.FileComparison(r'C:/example/file1.txt', r'D:/temp/RELATORIO_ATUAL.TXT')
+            # Using absolute paths
+            >>> oHelper.FileComparison(r'C:/example/file1.txt', r'D:/temp/file2.txt')
+            # Using current script directory for both files
+            >>> oHelper.FileComparison(self.oHelper.GetCurrentPath() + 'expected.txt', self.oHelper.GetCurrentPath() + 'generated.txt')
         """
         return self.__webapp.file_comparison(base_file=base_file, current_file=current_file)
     
@@ -1607,11 +1605,11 @@ class Webapp():
         """Returns the current working directory (root where the test script is being executed).
 
         Primary usage:
-        - Build file paths (baseline, reports, exports) without relying on hard‑coded absolute paths.
-        - Ensure portability between local execution and SmartTest.
+            - Build file paths (baseline, reports, exports) without relying on hard‑coded absolute paths.
+            - Ensure portability between local execution and SmartTest.
 
         Return:
-            str: Absolute path of the current directory (without trailing slash).
+            str: Absolute path of the current directory (with trailing slash).
 
         Examples:
             >>> base_dir = oHelper.GetCurrentPath()
@@ -2180,24 +2178,18 @@ class Poui():
     def FileComparison(self, base_file:str, current_file:str) -> bool:
         """Compares two files and returns True if they are byte‑for‑byte identical.
 
-        Path resolution:
-        1. If you pass only the file name (no directory), it will be looked up inside the folder defined by
-           "BaselinePath" in config.json.
-        2. If you pass a full path (absolute or relative including a directory component), that path is used
-           as-is and is NOT concatenated with "BaselinePath".
+        Attention to the use of file paths:
+            1. Bare file name (no directory) -> looked up under "BaselinePath" (or cwd if BaselinePath missing/empty).
+            2. Path with a directory component (absolute or relative) -> used as provided; no BaselinePath prefix.
 
-        Attention (config.json):
-        - Ensure the "BaselinePath" key is declared and points to the baseline folder of protheus_data.
-          Example:
-              "BaselinePath": "C:/TOTVS/Protheus/bra/12.1.2510/Protheus_data/baseline"
+        Config note:
+            - Define "BaselinePath" (e.g. "BaselinePath": "C:/TOTVS/Protheus/.../baseline") to avoid unintended
+              fallback to the current working directory and potential "file not found" errors.
 
         Files in the script root:
-        - If the file you want to compare is located in the test script root folder, use the `GetCurrentPath()` 
-          function to obtain that path in a portable way (local execution and SmartTest).
-          Example:
-              base = GetCurrentPath() + 'esperado.txt'
-              current = GetCurrentPath() + 'gerado.txt'
-              oHelper.FileComparison(base, current)
+            - If the file you want to compare is located in the test script root folder, use the `GetCurrentPath()`
+              function to obtain that path in a portable way (local execution and SmartTest). `GetCurrentPath()`
+              already returns a path with a trailing separator.
 
         Return values:
             True  -> identical content
@@ -2205,24 +2197,28 @@ class Poui():
             (If a file does not exist the framework logs an error and the test fails.)
 
         Usage examples:
+            # Using BaselinePath (or cwd fallback if BaselinePath is empty)
             >>> oHelper.FileComparison('file1.txt', 'file2.txt')
-            >>> oHelper.FileComparison(r'C:/example/file1.txt', r'D:/temp/RELATORIO_ATUAL.TXT')
+            # Using absolute paths
+            >>> oHelper.FileComparison(r'C:/example/file1.txt', r'D:/temp/file2.txt')
+            # Using current script directory for both files
+            >>> oHelper.FileComparison(self.oHelper.GetCurrentPath() + 'expected.txt', self.oHelper.GetCurrentPath() + 'generated.txt')
         """
-        return self.__poui.file_comparison(base_file=base_file, current_file=current_file)
+        return self.__webapp.file_comparison(base_file=base_file, current_file=current_file)
     
     def GetCurrentPath(self) -> str:
         """Returns the current working directory (root where the test script is being executed).
 
         Primary usage:
-        - Build file paths (baseline, reports, exports) without relying on hard‑coded absolute paths.
-        - Ensure portability between local execution and SmartTest.
+            - Build file paths (baseline, reports, exports) without relying on hard‑coded absolute paths.
+            - Ensure portability between local execution and SmartTest.
 
         Return:
-            str: Absolute path of the current directory (without trailing slash).
+            str: Absolute path of the current directory (with trailing slash).
 
         Examples:
             >>> base_dir = oHelper.GetCurrentPath()
             >>> full_path = base_dir + 'report_base.txt'
         """
-        
+
         return self.__webapp.get_current_path()

--- a/tir/main.py
+++ b/tir/main.py
@@ -1597,7 +1597,7 @@ class Webapp():
             # Using absolute paths
             >>> oHelper.FileComparison(r'C:/example/file1.txt', r'D:/temp/file2.txt')
             # Using current script directory for both files
-            >>> oHelper.FileComparison(self.oHelper.GetCurrentPath() + 'expected.txt', self.oHelper.GetCurrentPath() + 'generated.txt')
+            >>> oHelper.FileComparison(oHelper.GetCurrentPath() + 'expected.txt', oHelper.GetCurrentPath() + 'generated.txt')
         """
         return self.__webapp.file_comparison(base_file=base_file, current_file=current_file)
     

--- a/tir/main.py
+++ b/tir/main.py
@@ -1569,7 +1569,56 @@ class Webapp():
 
         """
         return self.__webapp.rest_resgistry()
+    
+    def FileComparison(self, base_file:str, current_file:str) -> bool:
+        """Compares two files and returns True if they are byte‑for‑byte identical.
 
+        Path resolution:
+        1. If you pass only the file name (no directory), it will be looked up inside the folder defined by
+           "BaselinePath" in config.json.
+        2. If you pass a full path (absolute or relative including a directory component), that path is used
+           as-is and is NOT concatenated with "BaselinePath".
+
+        Attention (config.json):
+        - Ensure the "BaselinePath" key is declared and points to the baseline folder of protheus_data.
+          Example:
+              "BaselinePath": "C:/TOTVS/Protheus/bra/12.1.2510/Protheus_data/baseline"
+
+        Files in the script root:
+        - If the file you want to compare is located in the test script root folder, use the `GetCurrentPath()` 
+          function to obtain that path in a portable way (local execution and SmartTest).
+          Example:
+              base = GetCurrentPath() + 'esperado.txt'
+              current = GetCurrentPath() + 'gerado.txt'
+              oHelper.FileComparison(base, current)
+
+        Return values:
+            True  -> identical content
+            False -> different content
+            (If a file does not exist the framework logs an error and the test fails.)
+
+        Usage examples:
+            >>> oHelper.FileComparison('file1.txt', 'file2.txt')
+            >>> oHelper.FileComparison(r'C:/example/file1.txt', r'D:/temp/RELATORIO_ATUAL.TXT')
+        """
+        return self.__webapp.file_comparison(base_file=base_file, current_file=current_file)
+    
+    def GetCurrentPath(self) -> str:
+        """Returns the current working directory (root where the test script is being executed).
+
+        Primary usage:
+        - Build file paths (baseline, reports, exports) without relying on hard‑coded absolute paths.
+        - Ensure portability between local execution and SmartTest.
+
+        Return:
+            str: Absolute path of the current directory (without trailing slash).
+
+        Examples:
+            >>> base_dir = oHelper.GetCurrentPath()
+            >>> full_path = base_dir + 'report_base.txt'
+        """
+
+        return self.__webapp.get_current_path()
 
 class Apw():
 
@@ -2086,3 +2135,53 @@ class Poui():
         """
 
         self.__poui.click_switch(label=label, value=value, position=position)
+
+    def FileComparison(self, base_file:str, current_file:str) -> bool:
+        """Compares two files and returns True if they are byte‑for‑byte identical.
+
+        Path resolution:
+        1. If you pass only the file name (no directory), it will be looked up inside the folder defined by
+           "BaselinePath" in config.json.
+        2. If you pass a full path (absolute or relative including a directory component), that path is used
+           as-is and is NOT concatenated with "BaselinePath".
+
+        Attention (config.json):
+        - Ensure the "BaselinePath" key is declared and points to the baseline folder of protheus_data.
+          Example:
+              "BaselinePath": "C:/TOTVS/Protheus/bra/12.1.2510/Protheus_data/baseline"
+
+        Files in the script root:
+        - If the file you want to compare is located in the test script root folder, use the `GetCurrentPath()` 
+          function to obtain that path in a portable way (local execution and SmartTest).
+          Example:
+              base = GetCurrentPath() + 'esperado.txt'
+              current = GetCurrentPath() + 'gerado.txt'
+              oHelper.FileComparison(base, current)
+
+        Return values:
+            True  -> identical content
+            False -> different content
+            (If a file does not exist the framework logs an error and the test fails.)
+
+        Usage examples:
+            >>> oHelper.FileComparison('file1.txt', 'file2.txt')
+            >>> oHelper.FileComparison(r'C:/example/file1.txt', r'D:/temp/RELATORIO_ATUAL.TXT')
+        """
+        return self.__poui.file_comparison(base_file=base_file, current_file=current_file)
+    
+    def GetCurrentPath(self) -> str:
+        """Returns the current working directory (root where the test script is being executed).
+
+        Primary usage:
+        - Build file paths (baseline, reports, exports) without relying on hard‑coded absolute paths.
+        - Ensure portability between local execution and SmartTest.
+
+        Return:
+            str: Absolute path of the current directory (without trailing slash).
+
+        Examples:
+            >>> base_dir = oHelper.GetCurrentPath()
+            >>> full_path = base_dir + 'report_base.txt'
+        """
+        
+        return self.__webapp.get_current_path()

--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -1568,7 +1568,9 @@ class Base(unittest.TestCase):
         current_full: Path = self._extract_file_path(current_file).resolve()
 
         if not base_full.is_file() or not current_full.is_file():
-            self.log_error("Base and/or current file not found or is not a valid file. Please check the file name.")
+            self.log_error('Base and/or current file not found or is not a valid file. ' +
+                           'Please check the file name and "BaselinePath" in config.json. ' +
+                          f'base_file = "{base_full}", current_file = "{current_full}"')
 
         # Atalho rápido: tamanhos diferentes já garante desigualdade
         if base_full.stat().st_size != current_full.stat().st_size:
@@ -1583,4 +1585,5 @@ class Base(unittest.TestCase):
         return Path(path) / filename
     
     def get_current_path(self) -> str:
-        return os.getcwd()
+        current = os.getcwd()
+        return current + (os.sep if not current.endswith(os.sep) else "")

--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -1577,8 +1577,15 @@ class Base(unittest.TestCase):
             return False
         
         with open(base_full, 'rb') as f1, open(current_full, 'rb') as f2:
-            return f1.read() == f2.read()
-        
+            CHUNK_SIZE = 8192
+            while True:
+                chunk1 = f1.read(CHUNK_SIZE)
+                chunk2 = f2.read(CHUNK_SIZE)
+                if chunk1 != chunk2:
+                    return False
+                if not chunk1:  # End of file
+                    break
+            return True
     def _extract_file_path(self, file: str) -> Path:
         path: Path = Path(self.config.baseline_path) if Path(file).parent == Path(".") else Path(file).parent
         filename: str = Path(file).name

--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -1571,7 +1571,7 @@ class Base(unittest.TestCase):
             self.log_error('Base and/or current file not found or is not a valid file. ' +
                            'Please check the file name and "BaselinePath" in config.json. ' +
                           f'base_file = "{base_full}", current_file = "{current_full}"')
-
+            return False
         # Atalho rápido: tamanhos diferentes já garante desigualdade
         if base_full.stat().st_size != current_full.stat().st_size:
             return False

--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -1572,7 +1572,7 @@ class Base(unittest.TestCase):
                            'Please check the file name and "BaselinePath" in config.json. ' +
                           f'base_file = "{base_full}", current_file = "{current_full}"')
             return False
-        # Atalho rápido: tamanhos diferentes já garante desigualdade
+        # Quick shortcut: different sizes already guarantee inequality
         if base_full.stat().st_size != current_full.stat().st_size:
             return False
         

--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -1559,3 +1559,25 @@ class Base(unittest.TestCase):
 
         if pattern.findall(path):
             return pattern.sub(slash, path)
+
+    def file_comparison(self, base_file: str, current_file: str) -> bool:
+        base_full: Path = self._extract_file_path(base_file).resolve()
+        current_full: Path = self._extract_file_path(current_file).resolve()
+
+        if not base_full.is_file() or not current_full.is_file():
+            self.log_error("Base and/or current file not found or is not a valid file. Please check the file name.")
+
+        # Atalho rápido: tamanhos diferentes já garante desigualdade
+        if base_full.stat().st_size != current_full.stat().st_size:
+            return False
+        
+        with open(base_full, 'rb') as f1, open(current_full, 'rb') as f2:
+            return f1.read() == f2.read()
+        
+    def _extract_file_path(self, file: str) -> Path:
+        path: Path = Path(self.config.baseline_path) if Path(file).parent == Path(".") else Path(file).parent
+        filename: str = Path(file).name
+        return Path(path) / filename
+    
+    def get_current_path(self) -> str:
+        return os.getcwd()

--- a/tir/technologies/core/config.py
+++ b/tir/technologies/core/config.py
@@ -129,6 +129,7 @@ class ConfigLoader:
             self.api_json_path = str(data["APIJSONPATH"]) if "APIJSONPATH" in data else os.path.join(os.getcwd())
             self.server_mock  = str(data["ServerMock"]) if "ServerMock" in data else ""
             self.sso_login = ("SSOLogin" in data and bool(data["SSOLogin"]))
+            self.baseline_path = str(data["BaselinePath"]) if "BaselinePath" in data else ""
 
 
     def check_keys(self, json_data):
@@ -198,7 +199,8 @@ class ConfigLoader:
         "APIURLIP",
         "APIJSONPATH",
         "ServerMock",
-        "SSOLogin"
+        "SSOLogin",
+        "BaselinePath"
     ]
         keys_json = set(json_data.keys())
         wrong_keys = keys_json - set(valid_keys)


### PR DESCRIPTION
Este método foi criado a partir da task #CA-10973 do Ryver.
O objetivo dela é verificar se um arquivo é igual ao outro.
A ideia principal é comparar dois arquivos que estejam na mesma pasta, sendo definida no config.json pelo novo atributo "BaselinePath".
Porém, também é possível passar caminhos absolutos para referenciar um arquivo, ou um arquivo que esteja na mesma pasta de onde o script esteja sendo executado, com o auxilio da função `GetCurrentPath`.