### PR TITLE
Add GitHub Actions workflow for Google Chat notifications

### DIFF
--- a/.github/workflows/notify-google-chat.yml
+++ b/.github/workflows/notify-google-chat.yml
@@ -1,0 +1,23 @@
+name: Google Chat Notify
+
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  notify_google_chat:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - id: 'notify_google_chat'
+        uses: 'google-github-actions/send-google-chat-webhook@v0.0.4'
+        with:
+          webhook_url: '${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}'
+          mention: "<users/all>"


### PR DESCRIPTION
Implement a GitHub Actions workflow to send notifications to Google Chat upon repository events. This addition enhances communication and keeps team members informed about changes in the repository.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Manual

**Test Configuration**:
* Tested the workflow by triggering it manually and verifying that notifications are sent to the specified Google Chat channel.

