### PR TITLE
Add diagnostic IO checks for screenshot directory permissions

### DIFF
--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,123 @@
+import tempfile
+from pathlib import Path
+import types
+import uuid
+
+import pytest
+
+import importlib.util
+
+# Load `Log` directly from file to avoid importing package-level dependencies
+repo_root = Path(__file__).resolve().parents[1]
+log_path = repo_root / 'tir' / 'technologies' / 'core' / 'log.py'
+spec = importlib.util.spec_from_file_location('tir_log', str(log_path))
+mod = importlib.util.module_from_spec(spec)
+
+# Inject minimal tir package stubs to avoid importing heavy dependencies during tests
+import sys
+pkg = types.ModuleType('tir')
+sys.modules['tir'] = pkg
+sys.modules['tir.technologies'] = types.ModuleType('tir.technologies')
+sys.modules['tir.technologies.core'] = types.ModuleType('tir.technologies.core')
+
+# Minimal ConfigLoader stub
+cfg_mod = types.ModuleType('tir.technologies.core.config')
+class DummyConfig:
+    def __init__(self, path=None):
+        self.issue = ''
+        self.execution_id = ''
+        self.country = 'BRA'
+        self.release = ''
+        self.logurl1 = ''
+        self.logurl2 = ''
+        self.smart_test = False
+        self.log_http = ''
+        self.num_exec = None
+        self.api_url = ''
+        self.api_url_ip = ''
+        self.api_json_path = str(repo_root / 'Log')
+        self.debug_log = False
+cfg_mod.ConfigLoader = lambda path=None: DummyConfig(path)
+sys.modules['tir.technologies.core.config'] = cfg_mod
+
+# Minimal logging_config stub
+logcfg_mod = types.ModuleType('tir.technologies.core.logging_config')
+import logging
+def logger():
+    return logging.getLogger('test_logger')
+logcfg_mod.logger = logger
+sys.modules['tir.technologies.core.logging_config'] = logcfg_mod
+
+spec.loader.exec_module(mod)
+Log = mod.Log
+
+
+def make_log_with_cfg(tmp_dir: Path):
+    l = Log(user='tester', station='station')
+    class Cfg:
+        pass
+    cfg = Cfg()
+    cfg.log_http = str(tmp_dir)
+    cfg.country = 'BRA'
+    cfg.release = '1.0'
+    cfg.issue = 'ISS'
+    cfg.execution_id = 'EID'
+    cfg.debug_log = False
+    l.config = cfg
+    return l
+
+
+def test_diagnostic_io_reports(tmp_path):
+    l = make_log_with_cfg(tmp_path)
+    res = l.diagnostic_io(tmp_path)
+    assert 'user' in res
+    assert 'target' in res
+    assert res['exists'] is True
+    assert isinstance(res['readable'], bool)
+    assert isinstance(res['writable'], bool)
+
+
+def test_take_screenshot_writes_file(tmp_path):
+    l = make_log_with_cfg(tmp_path)
+
+    # Prepare a fake driver that actually writes the file so we can assert existence
+    captured = []
+    def save_screenshot(path):
+        captured.append(path)
+        Path(path).write_text('screenshot')
+        return True
+
+    driver = types.SimpleNamespace()
+    driver.save_screenshot = save_screenshot
+
+    screenshot_name = 'my_test'
+    stack_item = f"testcase_{uuid.uuid4().hex[:6]}"
+
+    l.take_screenshot_log(driver, description=screenshot_name, stack_item=stack_item)
+
+    testsuite = l.get_file_name("testsuite")
+    folder_path = Path(l.config.log_http, l.config.country, l.release, l.config.issue, l.config.execution_id, testsuite)
+    # Assert that driver was called and file was created at that path
+    assert captured, "Driver.save_screenshot was not called"
+    written_path = Path(captured[0])
+    assert written_path.exists()
+
+
+def test_take_screenshot_fallback_on_write_fail(tmp_path, monkeypatch):
+    l = make_log_with_cfg(tmp_path)
+
+    # Simulate write failure (e.g., directory read-only)
+    def failing_save_screenshot(path):
+        raise PermissionError("Simulated write fail")
+
+    driver = types.SimpleNamespace()
+    driver.save_screenshot = failing_save_screenshot
+
+    # Monkeypatch tempfile.gettempdir to a controlled dir
+    temp_dir = tmp_path / 'fallback'
+    temp_dir.mkdir()
+    monkeypatch.setattr('tempfile.gettempdir', lambda: str(temp_dir))
+
+    # Should not crash; should log and continue
+    l.take_screenshot_log(driver, description='fail_test', stack_item='testcase_123')
+    # Verify if file was created in fallback (if applicable)

--- a/tir/technologies/core/log.py
+++ b/tir/technologies/core/log.py
@@ -14,6 +14,7 @@ import json
 from datetime import datetime
 from tir.technologies.core.config import ConfigLoader
 from tir.technologies.core.logging_config import logger
+import getpass
 
 class Log:
     """
@@ -615,16 +616,48 @@ class Log:
             if self.config.log_http:
                 folder_path = Path(self.config.log_http, self.config.country, self.release, self.config.issue, self.config.execution_id, testsuite)
                 path = Path(folder_path, screenshot_file)
-                os.makedirs(Path(folder_path))
+                folder_path.mkdir(parents=True, exist_ok=True)
             else:
                 path = Path("/tmp/Log", self.station, screenshot_file) if sys.platform.lower() == "linux" else Path("Log", self.station, screenshot_file)
-                os.makedirs(path)
+                path.parent.mkdir(parents=True, exist_ok=True)
         except OSError:
             pass
 
         try:
-            driver.save_screenshot(str(path))
-            logger().debug(f"Screenshot file created successfully: {path}")
+            parent = path.parent
+            if not parent.exists():
+                parent.mkdir(parents=True, exist_ok=True)
+
+            # Complementary diagnostic
+            try:
+                diag = self.diagnostic_io(parent)
+                logger().debug(f"Diagnostic IO result: {diag}")
+            except Exception:
+                pass
+
+            # More reliable writability check: try creating a temporary file
+            try:
+                test_file = parent / f".write_test_{uuid.uuid4().hex}"
+                with open(test_file, "w") as tf:
+                    tf.write("")
+                test_file.unlink()
+            except Exception as write_err:
+                logger().warning(f"Screenshot directory not writable: {parent} - {write_err}")
+                # Fallback to system temp directory
+                try:
+                    import tempfile
+                    tmp_dir = Path(tempfile.gettempdir())
+                    path = Path(tmp_dir, screenshot_file)
+                    parent = path.parent
+                    parent.mkdir(parents=True, exist_ok=True)
+                    logger().debug(f"Falling back to temp dir for screenshot: {path}")
+                except Exception as fallback_err:
+                    logger().exception(f"Failed to fallback to temp dir for screenshots: {fallback_err}")
+
+            if driver.save_screenshot(str(path)):
+                logger().debug(f"Screenshot file created successfully: {path}")
+            else:
+                logger().debug(f"Screenshot file fail: {path}")
         except Exception as e:
             logger().exception(f"Warning Log Error save_screenshot exception {str(e)}")
 
@@ -699,3 +732,42 @@ class Log:
 
         if pattern.findall(path):
             return pattern.sub(slash, path)
+
+    def diagnostic_io(self, target):
+        """
+        Diagnostic check for file/directory IO permissions.
+
+        :param target: Path or string to a file or directory to check
+        :return: dict with diagnostic info
+        """
+        try:
+            p = Path(target)
+            parent = p if p.is_dir() else p.parent
+
+            current_user = getpass.getuser()
+            current_domain = os.environ.get('USERDOMAIN', 'Unknown')
+
+            is_writable = os.access(str(parent), os.W_OK)
+            is_readable = os.access(str(parent), os.R_OK)
+            path_exists = parent.exists()
+
+            logger().info(
+                f"[DIAGNOSTIC] Write Attempt Details\n"
+                f" > User/Domain: {current_domain}\\{current_user}\n"
+                f" > Target Path: {parent}\n"
+                f" > Path Exists? {path_exists}\n"
+                f" > Has Read Permission? {is_readable}\n"
+                f" > Has Write Permission? {is_writable}"
+            )
+
+            return {
+                'user': current_user,
+                'domain': current_domain,
+                'target': str(parent),
+                'exists': path_exists,
+                'readable': is_readable,
+                'writable': is_writable,
+            }
+        except Exception as e:
+            logger().exception(f"Diagnostic IO check failed: {e}")
+            return {'error': str(e)}


### PR DESCRIPTION
Implement diagnostic checks for file and directory IO permissions when saving screenshots. This enhancement improves error handling by verifying write and read permissions, and falls back to a temporary directory if the original path is not writable. No issues are fixed with this change.

## Type of change
- [x] Hotfix - Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Manual
- [ ] SmartTest

**Test Configuration**:
* Tested on various platforms to ensure directory permissions are correctly diagnosed and handled.

