### PR TITLE
Add restart_counter_param to log_error method in PouiInternal and Web…

### DIFF
--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -2421,7 +2421,7 @@ class PouiInternal(Base):
         except AttributeError:
             return self.search_element_position(label_text)
             
-    def log_error(self, message, new_log_line=True, skip_restart=False):
+    def log_error(self, message, new_log_line=True, skip_restart=False, restart_counter_param=None):
         """
         [Internal]
 
@@ -2439,7 +2439,7 @@ class PouiInternal(Base):
         """
 
         from tir.technologies.core.events import emit
-        emit('webapp.log_error', message=message, new_log_line=new_log_line, skip_restart=skip_restart)
+        emit('webapp.log_error', message=message, new_log_line=new_log_line, skip_restart=skip_restart, restart_counter_param=restart_counter_param)
 
         return
     
@@ -4436,18 +4436,11 @@ class PouiInternal(Base):
         po_item_list = self._get_po_item_list(value, second_value)
 
         if not po_item_list:
-            message = f'Item list {orig_value or orig_second_value} not found'
+            message = f"Item list '{orig_value or orig_second_value}' not found"
             if program_call:
                 self.config.routine_type = ''
                 self.config.routine = ''
-            self.log_error(message)
-            message = 'setUpClass - ' + message if self.log.get_testcase_stack() == 'setUpClass' else message
-            if self.log.get_testcase_stack() == 'setUpClass':
-                try:
-                    self.TearDown()
-                except Exception:
-                    pass
-            self.assertTrue(False, message)
+            self.log_error(message, restart_counter_param=3 if self.log.get_testcase_stack() == 'setUpClass' else 0)
 
         po_item_list_div = po_item_list.find_next('div')
         self.scroll_to_element(self.soup_to_selenium(po_item_list_div, twebview=True))
@@ -4896,14 +4889,7 @@ class PouiInternal(Base):
             message = f"Item list '{program_desc}' not found!"
             self.config.routine_type = ''
             self.config.routine = ''
-            self.log_error(message)            
-            message = 'setUpClass - ' + message if self.log.get_testcase_stack() == 'setUpClass' else message
-            if self.log.get_testcase_stack() == 'setUpClass':
-                try:
-                    self.TearDown()
-                except Exception:
-                    pass
-            self.assertTrue(False, message)
+            self.log_error(message, restart_counter_param=3 if self.log.get_testcase_stack() == 'setUpClass' else 0)
         item_list_data = self._get_item_list_data(po_item_list)
         return item_list_data.get('value').upper()
     

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -8102,7 +8102,7 @@ class WebappInternal(Base):
         except AttributeError:
             return self.search_element_position(label_text)
 
-    def log_error(self, message, new_log_line=True, skip_restart=False):
+    def log_error(self, message, new_log_line=True, skip_restart=False, restart_counter_param=None):
         """
         [Internal]
 
@@ -8125,6 +8125,8 @@ class WebappInternal(Base):
 
         if self.config.smart_test:
             self.log.log_exec_file()
+
+        self.restart_counter = restart_counter_param if restart_counter_param else self.restart_counter
 
         self.clear_grid()
         logger().warning(f"Warning log_error {message}")


### PR DESCRIPTION
# Descrição
Esta alteração corrige um **problema de escopo** com a variável `restart_counter ` entre as classes POUI e WebApp.

# Problema
A variável `restart_counter ` é uma variável de instância (não de classe), definida no construtor de cada classe. Quando métodos do POUI precisam reportar erros, o fluxo é delegado ao WebApp através de eventos, porém:

- Setar o valor de `restart_counter` no POUI não afeta o `restart_counter` do WebApp, pois são instâncias diferentes
- O tratamento de erro é executado no contexto do WebApp, usando o valor da instância do WebApp
- Sem passar o valor explicitamente, o WebApp não tem conhecimento do valor que o POUI deseja usar

# Solução

Foi adicionado um parâmetro para permitir passar o valor desejado de `restart_counter`:

### WebApp:

- Aceita o novo parâmetro opcional
- Se fornecido, sobrescreve o valor antes de processar o erro

### POUI:

- Aceita o novo parâmetro opcional
- Repassa o valor através do evento para o WebApp
- Utiliza o valor correto em contextos de setUpClass

# Impacto
- Permite controle explícito do contador independente do estado da instância
- Resolve inconsistências no tratamento de erros entre POUI e WebApp
- Mantém retrocompatibilidade (parâmetro opcional com fallback para o valor atual)

# Observação
Esta **solução é temporária**. O conflito será definitivamente resolvido quando a função de tratamento de erro do POUI for atualizada, pois atualmente está desatualizada e apenas desvia a execução para o WebApp via eventos. Quando a implementação do POUI estiver completa e não depender mais do desvio para o WebApp, este parâmetro adicional não será mais necessário.