### PR TITLE
Change the click type in fill_search_browse double_click calls

### DIFF
--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -277,7 +277,6 @@ class Base(unittest.TestCase):
 
         except Exception as e:
             try:
-                logger().warning(f"Warning double_click method Exception: {str(e)}")
                 self.scroll_to_element(element)
                 actions = ActionChains(self.driver)
                 actions.move_to_element(element)

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -2432,7 +2432,7 @@ class WebappInternal(Base):
             self.log_error(f"Couldn't search f{search_elements}  current value is {current_value.rstrip()}")
         self.send_keys(sel_browse_input(), Keys.ENTER)
         self.wait_blocker()
-        self.double_click(sel_browse_icon())
+        self.double_click(sel_browse_icon(), click_type=enum.ClickType.JS)
         return True
 
 


### PR DESCRIPTION
Alterando o modo de duplo clique para executar como JS no SearchBrowse, assim na primeira tentativa vai funcionar tanto na antiga home quanto na nova.