### PR TITLE
Hotfix/search browse filter

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -2138,7 +2138,7 @@ class WebappInternal(Base):
                 search_key = re.sub(r"\.+$", '', search_key.strip()).lower()
 
             endtime = time.time() + self.config.time_out
-            while time.time() < endtime and not tradiobuttonitens:
+            while time.time() < endtime and not success:
                 soup = self.get_current_DOM()
                 radio_menu = next(iter(soup.select(radio_term)), None) if self.webapp_shadowroot() else soup.select(radio_term)
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -2138,9 +2138,16 @@ class WebappInternal(Base):
                 search_key = re.sub(r"\.+$", '', search_key.strip()).lower()
 
             endtime = time.time() + self.config.time_out
-            while time.time() < endtime and not success:
+            while time.time() < endtime and not tradiobuttonitens:
+                """
+                    TODO: Check whether "tradiobuttonitems" should be used as the loop condition.
+                    It only contains the divs found in radio_menu, not the elements matching "search_key".
+                    Suggestion: Use the "success" variable as the loop condition.
+                """
                 soup = self.get_current_DOM()
-                radio_menu = next(iter(soup.select(radio_term)), None) if self.webapp_shadowroot() else soup.select(radio_term)
+                radio_menu_elements = soup.select(radio_term)
+                radio_menu_elements_filtered = list(filter(lambda x: self.element_is_displayed(x), radio_menu_elements))
+                radio_menu = next(iter(radio_menu_elements_filtered), None)
 
                 if radio_menu:
                     if self.webapp_shadowroot():


### PR DESCRIPTION
Foi identificado que em alguns casos, estava sendo encontrado mais de um elemento "wa-radio", e como for default é recuperado o primeiro, o primeiro estava oculto e não era o alvo, ocasionando o erro.