### PR TITLE
refactor: simplify label box selection logic in WebappInternal class

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -8963,13 +8963,8 @@ class WebappInternal(Base):
                                                                 direction=None, input_selector='wa-checkbox')
             label_box = filtered_labels_boxs
 
-        if len(filtered_labels_boxs) == 1:
-            label_box = filtered_labels_boxs[0]
-        
-        elif position <= len(filtered_labels_boxs):
-            position -= 1
-            label_box = filtered_labels_boxs[position].parent if not self.webapp_shadowroot() else filtered_labels_boxs[
-                position]
+        if filtered_labels_boxs:
+            label_box = filtered_labels_boxs[0].parent if not self.webapp_shadowroot() else filtered_labels_boxs[0]
 
         return label_box
 


### PR DESCRIPTION
As funções filter_label_element e search_element_position, quando há um positon, já retorna um único elemento com base no position, não precisa fazer a lógica novamente na função principal.