### PR TITLE
Implementar parâmetro para envio de parâmetro para ignorar certificad…

### DIFF
--- a/doc_files/source/configjson.rst
+++ b/doc_files/source/configjson.rst
@@ -136,6 +136,10 @@ Additional Parameters
      - str
      - Country will be seted as main in log of execution.
      - BRA
+   * - IgnoreCertificateErrors
+     - bool
+     - Ignore certificate erros. **Default:** false
+     - true
 
 
 ********************************

--- a/docs/_sources/configjson.rst.txt
+++ b/docs/_sources/configjson.rst.txt
@@ -136,6 +136,10 @@ Additional Parameters
      - str
      - Country will be seted as main in log of execution.
      - BRA
+   * - IgnoreCertificateErrors
+     - bool
+     - Ignore certificate erros. **Default:** false
+     - true
 
 
 ********************************

--- a/docs/configjson.html
+++ b/docs/configjson.html
@@ -264,6 +264,11 @@ The config.json file is where the configs of the tests are defined.</p>
 <td><p>Country will be seted as main in log of execution.</p></td>
 <td><p>BRA</p></td>
 </tr>
+<tr class="row-even"><td><p>IgnoreCertificateErrors</p></td>
+<td><p>bool</p></td>
+<td><p>Ignore certificate erros. <strong>Default:</strong> false</p></td>
+<td><p>true</p></td>
+</tr>
 </tbody>
 </table>
 </section>

--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -1196,6 +1196,12 @@ class Base(unittest.TestCase):
             firefox_options = FirefoxOpt()
             if self.config.headless:
                 firefox_options.add_argument('-headless')
+            if self.config.ignore_certificate_errors:
+                try:
+                    firefox_options.set_capability("acceptInsecureCerts", True)
+                    firefox_options.set_preference("webdriver_accept_untrusted_certs", True)
+                except Exception:
+                    pass
             service = FirefoxService(executable_path=driver_path, log_path=log_path)
             self.driver = webdriver.Firefox(options=firefox_options, service=service)
         elif self.config.browser.lower() == "chrome":
@@ -1206,6 +1212,8 @@ class Base(unittest.TestCase):
             chrome_options.add_argument('--log-level=3')
             if self.config.headless:
                 chrome_options.add_argument('force-device-scale-factor=0.77')
+            if self.config.ignore_certificate_errors:
+                chrome_options.add_argument('--ignore-certificate-errors')
 
             if self.config.chromedriver_auto_install:
 
@@ -1242,6 +1250,8 @@ class Base(unittest.TestCase):
             chrome_options.add_argument(f'--url="{self.config.url}"')
             chrome_options.add_argument(f'--program="{self.config.start_program}"')
             chrome_options.add_argument('--quiet')
+            if self.config.ignore_certificate_errors:
+                chrome_options.add_argument('--ignore-certificate-errors')
             chrome_options.binary_location = self.config.electron_binary_path
             self.driver = webdriver.Chrome(options=chrome_options, executable_path=driver_path)
 

--- a/tir/technologies/core/config.py
+++ b/tir/technologies/core/config.py
@@ -129,6 +129,7 @@ class ConfigLoader:
             self.api_json_path = str(data["APIJSONPATH"]) if "APIJSONPATH" in data else os.path.join(os.getcwd())
             self.server_mock  = str(data["ServerMock"]) if "ServerMock" in data else ""
             self.sso_login = ("SSOLogin" in data and bool(data["SSOLogin"]))
+            self.ignore_certificate_errors = ("IgnoreCertificateErrors" in data and bool(data["IgnoreCertificateErrors"]))
 
 
     def check_keys(self, json_data):
@@ -198,7 +199,8 @@ class ConfigLoader:
         "APIURLIP",
         "APIJSONPATH",
         "ServerMock",
-        "SSOLogin"
+        "SSOLogin",
+        "IgnoreCertificateErrors"
     ]
         keys_json = set(json_data.keys())
         wrong_keys = keys_json - set(valid_keys)


### PR DESCRIPTION
# Description

Implementation of SSL/TLS certificate validation bypass for Firefox WebDriver. This change allows automated tests to access URLs with self-signed or invalid certificates, eliminating failures caused by SSL/TLS certificate errors.
Objective: Enable test execution in development/staging environments that use self-signed or invalid certificates without requiring system configuration modifications.
Motivation: Many test environments use invalid certificates, preventing automation without this configuration.

## Type of change

Please delete options that are not relevant.
- [ ] Hotfix - Bug fix (non-breaking change which fixes an issue) 
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual
- [ ] SmartTest

**Test Configuration**:
The implementation successfully bypasses SSL/TLS validation when enabled and maintains strict validation when disabled, providing flexible control over certificate verification.
