### PR TITLE
Hotfix: improve grid line collection and first-row selection stability

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -7071,6 +7071,7 @@ class WebappInternal(Base):
             before_texts = list(map(lambda x: x.text, before_texts))
             after_texts = []
             down_count = 0
+            logger().debug(f"Starting search for row {row_num+1}. Initial visible lines: {len(before_texts)}")
             if grid_lines():
                 self.send_action(action=self.click, element=lambda: next(iter(grid_lines())), click_type=3)
                 endtime = time.time() + self.config.time_out
@@ -7084,14 +7085,18 @@ class WebappInternal(Base):
 
                     if len(before_texts) > row_num:
                         row_list = list(filter(lambda x: x.text == before_texts[row_num], grid_lines()))
+                        logger().debug(f"Row found, ending search")
                         break
 
                     ActionChains(self.driver).key_down(Keys.PAGE_DOWN).perform()
+                    down_count += 1
                     ActionChains(self.driver).key_down(Keys.PAGE_DOWN).perform()
                     down_count += 1
                     self.wait_blocker()
 
                     after_texts = list(map(lambda x: x.text, grid_lines()))
+                
+                logger().debug(f"Search completed. Total lines collected: {len(before_texts)}, down_count: {down_count}")
 
             return next(iter(row_list), None), down_count
 
@@ -9613,6 +9618,7 @@ class WebappInternal(Base):
             before_texts = list(map(lambda x: x.text, before_texts))
             after_texts = []
             down_count = 0
+            logger().debug(f"Starting line count. Initial visible lines: {len(before_texts)}")
             if grid_lines():
                 self.send_action(action=self.click, element=lambda: next(iter(grid_lines())), click_type=3)
                 ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
@@ -9625,6 +9631,7 @@ class WebappInternal(Base):
                             before_texts.append(i)
 
                     ActionChains(self.driver).key_down(Keys.PAGE_DOWN).perform()
+                    down_count += 1
                     ActionChains(self.driver).key_down(Keys.PAGE_DOWN).perform()
                     down_count += 1
                     self.wait_blocker()
@@ -9633,6 +9640,7 @@ class WebappInternal(Base):
 
                 ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
 
+                logger().debug(f"Count completed. Total lines: {len(before_texts)}, down_count: {down_count}")
                 return len(before_texts)
         else:
             return len(grid.select("tbody tr"))
@@ -10614,6 +10622,9 @@ class WebappInternal(Base):
         parent_classes_before = self.get_active_parent_class(element)
         parent_classes_after = parent_classes_before
 
+        children_classes_before = self.get_active_children_classes(element)
+        children_classes_after = children_classes_before
+
         classes_before = ''
         classes_after = classes_before
 
@@ -10631,7 +10642,11 @@ class WebappInternal(Base):
 
         endtime = time.time() + self.config.time_out
         try:
-            while ((time.time() < endtime) and (soup_before_event == soup_after_event) and (parent_classes_before == parent_classes_after) and (classes_before == classes_after) ):
+            while ((time.time() < endtime) and \
+                    (soup_before_event == soup_after_event) and \
+                    (parent_classes_before == parent_classes_after) and \
+                    (children_classes_before == children_classes_after) and \
+                    (classes_before == classes_after) ):
                 logger().debug(f"Trying to send action")
                 if right_click:
                     soup_select = self.get_soup_select(".tmenupopupitem, wa-menu-popup-item")
@@ -10656,6 +10671,7 @@ class WebappInternal(Base):
                     soup_after_event = self.get_current_DOM(twebview=twebview)
 
                 parent_classes_after = self.get_active_parent_class(element)
+                children_classes_after = self.get_active_children_classes(element)
 
                 if element:
                     classes_after = self.get_selenium_attribute(element(), 'class')
@@ -10674,10 +10690,11 @@ class WebappInternal(Base):
             return False
 
         if self.config.smart_test or self.config.debug_log:
-            logger().debug(f"send_action method result = {soup_before_event != soup_after_event}")
-            logger().debug(f'send_action selenium status: {parent_classes_before != parent_classes_after}')
+            logger().debug(f"send_action soup = {soup_before_event != soup_after_event}")
+            logger().debug(f'send_action parent_classes: {parent_classes_before != parent_classes_after}')
+            logger().debug(f'send_action children_classes: {children_classes_before != children_classes_after}')
+            logger().debug(f'send_action classes: {classes_before == classes_after}')
         return soup_before_event != soup_after_event
-
 
     def get_selenium_attribute(self, element, attribute):
         try:

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -7071,11 +7071,20 @@ class WebappInternal(Base):
             before_texts = list(map(lambda x: x.text, before_texts))
             after_texts = []
             down_count = 0
+            last_line_selected = False
             logger().debug(f"Starting search for row {row_num+1}. Initial visible lines: {len(before_texts)}")
             if grid_lines():
-                self.send_action(action=self.click, element=lambda: next(iter(grid_lines())), click_type=3)
-                endtime = time.time() + self.config.time_out
-                while endtime > time.time() and next(reversed(after_texts), None) != next(reversed(before_texts), None):
+                first_line = lambda: next(iter(grid_lines()))
+                last_line = lambda: next(reversed(grid_lines()))
+
+                if not first_line().find_elements(By.CSS_SELECTOR, "td.selected-cell"):
+                    self.send_action(action=self.click, element=lambda: first_line(), click_type=3)
+                ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
+                
+                endtime = time.time() + self.config.time_out                
+                while endtime > time.time() and \
+                        next(reversed(after_texts), None) != next(reversed(before_texts), None) and \
+                        not last_line_selected:
 
                     after_texts = list(map(lambda x: x.text, grid_lines()))
 
@@ -7090,11 +7099,11 @@ class WebappInternal(Base):
 
                     ActionChains(self.driver).key_down(Keys.PAGE_DOWN).perform()
                     down_count += 1
-                    ActionChains(self.driver).key_down(Keys.PAGE_DOWN).perform()
-                    down_count += 1
                     self.wait_blocker()
 
                     after_texts = list(map(lambda x: x.text, grid_lines()))
+                    if last_line().find_elements(By.CSS_SELECTOR, "td.selected-cell"):
+                        last_line_selected = True
                 
                 logger().debug(f"Search completed. Total lines collected: {len(before_texts)}, down_count: {down_count}")
 
@@ -9618,12 +9627,20 @@ class WebappInternal(Base):
             before_texts = list(map(lambda x: x.text, before_texts))
             after_texts = []
             down_count = 0
+            last_line_selected = False
             logger().debug(f"Starting line count. Initial visible lines: {len(before_texts)}")
             if grid_lines():
-                self.send_action(action=self.click, element=lambda: next(iter(grid_lines())), click_type=3)
+                first_line = lambda: next(iter(grid_lines()))
+                last_line = lambda: next(reversed(grid_lines()))
+
+                if not first_line().find_elements(By.CSS_SELECTOR, "td.selected-cell"):
+                    self.send_action(action=self.click, element=lambda: first_line(), click_type=3)
                 ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
+
                 endtime = time.time() + self.config.time_out
-                while endtime > time.time() and next(reversed(after_texts), None) != next(reversed(before_texts), None):
+                while endtime > time.time() and \
+                        next(reversed(after_texts), None) != next(reversed(before_texts), None) and \
+                        not last_line_selected:
 
                     after_texts = list(map(lambda x: x.text, grid_lines()))
                     for i in after_texts:
@@ -9632,11 +9649,11 @@ class WebappInternal(Base):
 
                     ActionChains(self.driver).key_down(Keys.PAGE_DOWN).perform()
                     down_count += 1
-                    ActionChains(self.driver).key_down(Keys.PAGE_DOWN).perform()
-                    down_count += 1
                     self.wait_blocker()
 
                     after_texts = list(map(lambda x: x.text, grid_lines()))
+                    if last_line().find_elements(By.CSS_SELECTOR, "td.selected-cell"):
+                        last_line_selected = True
 
                 ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
 
@@ -10718,7 +10735,31 @@ class WebappInternal(Base):
             if self.config.smart_test or self.config.debug_log:
                 logger().exception(f"Warning Exception get_active_parent_class: {str(e)}")
 
-
+    def get_active_children_classes(self, element=None):
+        """
+        Returns class list of all descendants of an element
+        """
+        try:
+            if element:
+                from selenium.webdriver.common.by import By
+                # Pega todos os descendentes do elemento
+                descendants = element().find_elements(By.XPATH, ".//*")
+                # Coleta as classes de cada descendente
+                classes_list = []
+                for descendant in descendants:
+                    try:
+                        class_attr = descendant.get_attribute('class')
+                        if class_attr:
+                            classes_list.append(class_attr)
+                    except StaleElementReferenceException:
+                        continue
+                return classes_list
+            return []
+        except Exception as e:
+            if self.config.smart_test or self.config.debug_log:
+                logger().debug(f"Warning Exception get_active_children_classes {str(e)}")
+            return []
+        
     def image_compare(self, img1, img2):
         """
         Returns differences between 2 images in Gray Scale.

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -6913,6 +6913,16 @@ class WebappInternal(Base):
         """
         return element.get_attribute('class').lower().strip() == 'selected-cell'
 
+    def has_selected_cell(self, row_element):
+        """
+        [Internal]
+        Checks if a row element has any selected cell.
+        
+        :param element: Row element to check
+        :return: True if row has a selected cell, False otherwise
+        """
+        return bool(row_element.find_elements(By.CSS_SELECTOR, "td.selected-cell"))
+
     def get_selenium_column_element(self, xpath):
         """
         [Internal]
@@ -7072,14 +7082,18 @@ class WebappInternal(Base):
             after_texts = []
             down_count = 0
             last_line_selected = False
+
             logger().debug(f"Starting search for row {row_num+1}. Initial visible lines: {len(before_texts)}")
             if grid_lines():
                 first_line = lambda: next(iter(grid_lines()))
                 last_line = lambda: next(reversed(grid_lines()))
-
-                if not first_line().find_elements(By.CSS_SELECTOR, "td.selected-cell"):
-                    self.send_action(action=self.click, element=lambda: first_line(), click_type=3)
-                ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
+                
+                endtime = time.time() + self.config.time_out  
+                success = False    
+                while endtime > time.time() and not success:
+                    self.click(element=first_line(), click_type=enum.ClickType(3))
+                    ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
+                    success = self.has_selected_cell(row_element=first_line())
                 
                 endtime = time.time() + self.config.time_out                
                 while endtime > time.time() and \
@@ -7102,8 +7116,7 @@ class WebappInternal(Base):
                     self.wait_blocker()
 
                     after_texts = list(map(lambda x: x.text, grid_lines()))
-                    if last_line().find_elements(By.CSS_SELECTOR, "td.selected-cell"):
-                        last_line_selected = True
+                    last_line_selected = self.has_selected_cell(row_element=last_line())
                 
                 logger().debug(f"Search completed. Total lines collected: {len(before_texts)}, down_count: {down_count}")
 
@@ -9628,15 +9641,19 @@ class WebappInternal(Base):
             after_texts = []
             down_count = 0
             last_line_selected = False
+
             logger().debug(f"Starting line count. Initial visible lines: {len(before_texts)}")
             if grid_lines():
                 first_line = lambda: next(iter(grid_lines()))
                 last_line = lambda: next(reversed(grid_lines()))
 
-                if not first_line().find_elements(By.CSS_SELECTOR, "td.selected-cell"):
-                    self.send_action(action=self.click, element=lambda: first_line(), click_type=3)
-                ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
-
+                endtime = time.time() + self.config.time_out  
+                success = False    
+                while endtime > time.time() and not success:
+                    self.click(element=first_line(), click_type=enum.ClickType(3))
+                    ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
+                    success = self.has_selected_cell(row_element=first_line())
+                
                 endtime = time.time() + self.config.time_out
                 while endtime > time.time() and \
                         next(reversed(after_texts), None) != next(reversed(before_texts), None) and \
@@ -9652,8 +9669,7 @@ class WebappInternal(Base):
                     self.wait_blocker()
 
                     after_texts = list(map(lambda x: x.text, grid_lines()))
-                    if last_line().find_elements(By.CSS_SELECTOR, "td.selected-cell"):
-                        last_line_selected = True
+                    last_line_selected = self.has_selected_cell(row_element=last_line())
 
                 ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
 
@@ -10742,9 +10758,7 @@ class WebappInternal(Base):
         try:
             if element:
                 from selenium.webdriver.common.by import By
-                # Pega todos os descendentes do elemento
                 descendants = element().find_elements(By.XPATH, ".//*")
-                # Coleta as classes de cada descendente
                 classes_list = []
                 for descendant in descendants:
                     try:

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -7085,7 +7085,8 @@ class WebappInternal(Base):
             last_line = lambda: next(reversed(grid_lines()))
             
             # Click first line
-            self.select_first_line(first_line())
+            self.select_tr(first_line())
+            ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
 
             before_texts = list(filter(lambda x: hasattr(x, 'text'), grid_lines()))
             before_texts = list(map(lambda x: x.text, before_texts))
@@ -7149,7 +7150,7 @@ class WebappInternal(Base):
 
         return before_texts, row_element, down_count
 
-    def select_first_line(self, first_line):
+    def select_tr(self, first_line):
         """
         [Internal]
 
@@ -7163,8 +7164,7 @@ class WebappInternal(Base):
         endtime = time.time() + self.config.time_out        
         while endtime > time.time() and not success:
             self.click(element=first_line, click_type=enum.ClickType(3))
-            time.sleep(0.5)
-            ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
+            time.sleep(0.5)            
             success = self.has_selected_cell(row_element=first_line)
 
     def get_obscure_gridline(self, grid, row_num=0):

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -7085,12 +7085,7 @@ class WebappInternal(Base):
             last_line = lambda: next(reversed(grid_lines()))
             
             # Click first line
-            endtime = time.time() + self.config.time_out  
-            success = False    
-            while endtime > time.time() and not success:
-                self.click(element=first_line(), click_type=enum.ClickType(3))
-                ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
-                success = self.has_selected_cell(row_element=first_line())
+            self.select_first_line(first_line())
 
             before_texts = list(filter(lambda x: hasattr(x, 'text'), grid_lines()))
             before_texts = list(map(lambda x: x.text, before_texts))
@@ -7153,6 +7148,24 @@ class WebappInternal(Base):
                 ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
 
         return before_texts, row_element, down_count
+
+    def select_first_line(self, first_line):
+        """
+        [Internal]
+
+        Selects the first visible row in the grid.
+
+        :param first_line: First row element of the grid.
+        :type first_line: Selenium object
+        """
+        success = False    
+
+        endtime = time.time() + self.config.time_out        
+        while endtime > time.time() and not success:
+            self.click(element=first_line, click_type=enum.ClickType(3))
+            time.sleep(0.5)
+            ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
+            success = self.has_selected_cell(row_element=first_line)
 
     def get_obscure_gridline(self, grid, row_num=0):
         """

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -7108,15 +7108,7 @@ class WebappInternal(Base):
 
                 # If looking for specific row and found it, capture the element
                 if row_num is not None and len(before_texts) > row_num and row_element is None:
-                    logger().debug(f"[DEBUG] Target row_num: {row_num}, before_texts length: {len(before_texts)}")
-                    logger().debug(f"[DEBUG] Target text (before_texts[{row_num}]): '{before_texts[row_num]}'")
-                    logger().debug(f"[DEBUG] Current visible grid_lines count: {len(grid_lines())}")
-                    logger().debug(f"[DEBUG] Visible texts: {[x.text for x in grid_lines()]}")
                     row_element = next(iter(list(filter(lambda x: x.text == before_texts[row_num], grid_lines()))), None)
-                    if row_element:
-                        logger().debug(f"[DEBUG] Row element captured! Element text: '{row_element.text}'")
-                    else:
-                        logger().debug(f"[DEBUG] Row element NOT found in visible lines!")
                     logger().debug(f"Row found during scroll")
                     break
 
@@ -7140,6 +7132,8 @@ class WebappInternal(Base):
         """
         logger().debug(f"Starting search for row {row_num+1}")
         before_texts, row_element, down_count = self._scroll_and_collect_grid_lines(grid, row_num)
+
+        logger().debug(f"Text row: {row_element.text}")
         
         msg_success = 'Search completed. ' if row_element else f"Row {row_num+1} doesn't found! "
         msg_success += f"Total lines collected: {len(before_texts)}, down_count: {down_count}"

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -7087,6 +7087,7 @@ class WebappInternal(Base):
                         break
 
                     ActionChains(self.driver).key_down(Keys.PAGE_DOWN).perform()
+                    ActionChains(self.driver).key_down(Keys.PAGE_DOWN).perform()
                     down_count += 1
                     self.wait_blocker()
 
@@ -9623,6 +9624,7 @@ class WebappInternal(Base):
                         if i not in before_texts:
                             before_texts.append(i)
 
+                    ActionChains(self.driver).key_down(Keys.PAGE_DOWN).perform()
                     ActionChains(self.driver).key_down(Keys.PAGE_DOWN).perform()
                     down_count += 1
                     self.wait_blocker()

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -7119,7 +7119,8 @@ class WebappInternal(Base):
                 after_texts = list(map(lambda x: x.text, grid_lines()))
                 last_line_selected = self.has_selected_cell(row_element=last_line())
 
-            ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
+            if row_num is None:
+                ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
 
         return before_texts, row_element, down_count
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -7094,7 +7094,7 @@ class WebappInternal(Base):
                 ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
                 success = self.has_selected_cell(row_element=first_line())
             
-            # Scroll and collect all lines
+            # Scroll and collect all lines with PAGE_DOWN
             endtime = time.time() + self.config.time_out
             while endtime > time.time() and \
                     next(reversed(after_texts), None) != next(reversed(before_texts), None) and \
@@ -7118,6 +7118,34 @@ class WebappInternal(Base):
 
                 after_texts = list(map(lambda x: x.text, grid_lines()))
                 last_line_selected = self.has_selected_cell(row_element=last_line())
+
+            # After PAGE_DOWN reaches the end, try DOWN arrow to catch remaining lines
+            if not row_element:  # Only if we haven't found the target row yet
+                logger().debug("Checking for additional lines with DOWN arrow")
+                additional_lines_found = True
+                while additional_lines_found and endtime > time.time():
+                    ActionChains(self.driver).key_down(Keys.DOWN).perform()
+                    self.wait_blocker()
+                    
+                    after_down = list(map(lambda x: x.text, grid_lines()))
+                    
+                    # Check if new lines appeared
+                    additional_lines_found = False
+                    for i in after_down:
+                        if i not in before_texts:
+                            before_texts.append(i)
+                            additional_lines_found = True
+                            logger().debug(f"Found additional line with DOWN: {i}")
+                    
+                    # If looking for specific row and found it
+                    if row_num is not None and len(before_texts) > row_num and row_element is None:
+                        row_element = next(iter(list(filter(lambda x: x.text == before_texts[row_num], grid_lines()))), None)
+                        logger().debug(f"Target row found with DOWN arrow")
+                        break
+                    
+                    # Stop if no new lines were found
+                    if not additional_lines_found:
+                        break
 
             if row_num is None:
                 ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -10663,29 +10663,18 @@ class WebappInternal(Base):
         parent_classes_before = self.get_active_parent_class(element)
         parent_classes_after = parent_classes_before
 
-        children_classes_before = self.get_active_children_classes(element)
-        children_classes_after = children_classes_before
-
         classes_before = self.get_selenium_attribute(element(), 'class') if element else ''
         classes_after = classes_before
 
-        loop_check = lambda: ((soup_before_event == soup_after_event) and \
-                              (sorted(shadow_roots_before) == sorted(shadow_roots_after)) and \
-                              (parent_classes_before == parent_classes_after) and \
-                              (children_classes_before == children_classes_after) and \
-                              (classes_before == classes_after))
-
-        return_check = lambda: ((soup_before_event != soup_after_event) or \
-                                (sorted(shadow_roots_before) != sorted(shadow_roots_after)) or \
-                                (parent_classes_before != parent_classes_after) or \
-                                (children_classes_before != children_classes_after) or \
-                                (classes_before != classes_after))
+        check_changed = lambda: ((soup_before_event != soup_after_event) or \
+                                 (sorted(shadow_roots_before) != sorted(shadow_roots_after)) or \
+                                 (parent_classes_before != parent_classes_after) or \
+                                 (classes_before != classes_after))
         
         string_debug = lambda: f"Results send_action check:\n" + \
                                f"soup = {soup_before_event != soup_after_event}\n" + \
                                f'shadow_roots: {sorted(shadow_roots_before) != sorted(shadow_roots_after)}\n' + \
                                f'parent_classes: {parent_classes_before != parent_classes_after}\n' + \
-                               f'children_classes: {children_classes_before != children_classes_after}\n' + \
                                f'classes: {classes_before != classes_after}'
 
         self.wait_blocker()
@@ -10698,7 +10687,7 @@ class WebappInternal(Base):
 
         endtime = time.time() + self.config.time_out
         try:
-            while ((time.time() < endtime) and loop_check()):
+            while ((time.time() < endtime) and not check_changed()):
                 logger().debug(f"Trying to send action")
 
                 if right_click:
@@ -10725,7 +10714,6 @@ class WebappInternal(Base):
 
                 shadow_roots_after = self.get_shadow_roots_content()
                 parent_classes_after = self.get_active_parent_class(element)
-                children_classes_after = self.get_active_children_classes(element)
 
                 if element:
                     classes_after = self.get_selenium_attribute(element(), 'class')
@@ -10746,7 +10734,7 @@ class WebappInternal(Base):
         if self.config.smart_test or self.config.debug_log:
             logger().debug(string_debug())
         
-        return return_check()
+        return check_changed()
 
     def get_selenium_attribute(self, element, attribute):
         try:

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -10652,6 +10652,9 @@ class WebappInternal(Base):
         soup_before_event = self.get_current_DOM(twebview=twebview)
         soup_after_event = soup_before_event
 
+        shadow_roots_before = self.get_shadow_roots_content()
+        shadow_roots_after = shadow_roots_before
+
         parent_classes_before = self.get_active_parent_class(element)
         parent_classes_after = parent_classes_before
 
@@ -10677,6 +10680,7 @@ class WebappInternal(Base):
         try:
             while ((time.time() < endtime) and \
                     (soup_before_event == soup_after_event) and \
+                    (shadow_roots_before == shadow_roots_after) and \
                     (parent_classes_before == parent_classes_after) and \
                     (children_classes_before == children_classes_after) and \
                     (classes_before == classes_after) ):
@@ -10703,6 +10707,7 @@ class WebappInternal(Base):
                 else:
                     soup_after_event = self.get_current_DOM(twebview=twebview)
 
+                shadow_roots_after = self.get_shadow_roots_content()
                 parent_classes_after = self.get_active_parent_class(element)
                 children_classes_after = self.get_active_children_classes(element)
 
@@ -10723,11 +10728,17 @@ class WebappInternal(Base):
             return False
 
         if self.config.smart_test or self.config.debug_log:
-            logger().debug(f"send_action soup = {soup_before_event != soup_after_event}")
+            logger().debug(f"send_action soup = {soup_before_event != soup_after_event}")            
+            logger().debug(f'send_action shadow_roots: {shadow_roots_before != shadow_roots_after}')
             logger().debug(f'send_action parent_classes: {parent_classes_before != parent_classes_after}')
             logger().debug(f'send_action children_classes: {children_classes_before != children_classes_after}')
             logger().debug(f'send_action classes: {classes_before == classes_after}')
-        return soup_before_event != soup_after_event
+        
+        return ((soup_before_event != soup_after_event) or \
+                (shadow_roots_before != shadow_roots_after) or \
+                (parent_classes_before != parent_classes_after) or \
+                (children_classes_before != children_classes_after) or \
+                (classes_before != classes_after))
 
     def get_selenium_attribute(self, element, attribute):
         try:
@@ -10735,6 +10746,51 @@ class WebappInternal(Base):
         except StaleElementReferenceException:
             return None
 
+    def get_shadow_roots_content(self):
+        """
+        [Internal]
+        Captures the content of all shadow roots in the current DOM.
+        Returns a dictionary with element identifiers and their shadow root HTML.
+        Cleans special characters like \n, \t, and multiple spaces.
+        """
+        try:
+            script = """
+            function getShadowRootsContent() {
+                const shadowElements = [];
+                const allElements = document.querySelectorAll('*');
+                
+                allElements.forEach((el, index) => {
+                    if (el.shadowRoot) {
+                        // Get innerHTML and clean special characters
+                        let innerHTML = el.shadowRoot.innerHTML;
+                        // Remove line breaks, tabs, and normalize spaces
+                        innerHTML = innerHTML
+                            .replace(/\\n/g, '')
+                            .replace(/\\t/g, '')
+                            .replace(/\\r/g, '')
+                            .replace(/\\s+/g, ' ')
+                            .trim();
+                        
+                        const elementInfo = {
+                            tagName: el.tagName,
+                            id: el.id || `shadow-${index}`,
+                            className: el.className,
+                            innerHTML: innerHTML
+                        };
+                        shadowElements.push(elementInfo);
+                    }
+                });
+                
+                return JSON.stringify(shadowElements);
+            }
+            return getShadowRootsContent();
+            """
+            result = self.driver.execute_script(script)
+            return result if result else '[]'
+        except Exception as e:
+            if self.config.smart_test or self.config.debug_log:
+                logger().debug(f"Warning Exception get_shadow_roots_content {str(e)}")
+            return '[]'
 
     def get_active_parent_class(self, element=None):
         """

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -7073,14 +7073,12 @@ class WebappInternal(Base):
         Returns tuple: (before_texts, row_element, down_count)
         """
         grid_lines = lambda: self.execute_js_selector('tbody tr', self.soup_to_selenium(grid))
-        before_texts = list(filter(lambda x: hasattr(x, 'text'), grid_lines()))
-        before_texts = list(map(lambda x: x.text, before_texts))
         after_texts = []
         down_count = 0
         last_line_selected = False
         row_element = None
 
-        logger().debug(f"Initial visible lines: {len(before_texts)}")
+        time.sleep(0.5)        
 
         if grid_lines():
             first_line = lambda: next(iter(grid_lines()))
@@ -7093,6 +7091,10 @@ class WebappInternal(Base):
                 self.click(element=first_line(), click_type=enum.ClickType(3))
                 ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
                 success = self.has_selected_cell(row_element=first_line())
+
+            before_texts = list(filter(lambda x: hasattr(x, 'text'), grid_lines()))
+            before_texts = list(map(lambda x: x.text, before_texts))
+            logger().debug(f"Initial visible lines: {len(before_texts)}")
             
             # Scroll and collect all lines with PAGE_DOWN
             endtime = time.time() + self.config.time_out

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -7108,7 +7108,15 @@ class WebappInternal(Base):
 
                 # If looking for specific row and found it, capture the element
                 if row_num is not None and len(before_texts) > row_num and row_element is None:
+                    logger().debug(f"[DEBUG] Target row_num: {row_num}, before_texts length: {len(before_texts)}")
+                    logger().debug(f"[DEBUG] Target text (before_texts[{row_num}]): '{before_texts[row_num]}'")
+                    logger().debug(f"[DEBUG] Current visible grid_lines count: {len(grid_lines())}")
+                    logger().debug(f"[DEBUG] Visible texts: {[x.text for x in grid_lines()]}")
                     row_element = next(iter(list(filter(lambda x: x.text == before_texts[row_num], grid_lines()))), None)
+                    if row_element:
+                        logger().debug(f"[DEBUG] Row element captured! Element text: '{row_element.text}'")
+                    else:
+                        logger().debug(f"[DEBUG] Row element NOT found in visible lines!")
                     logger().debug(f"Row found during scroll")
                     break
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -7065,6 +7065,64 @@ class WebappInternal(Base):
             return colors[status]
 
 
+    def _scroll_and_collect_grid_lines(self, grid, row_num=None):
+        """
+        [Internal]
+        Scrolls through grid and collects all line texts.
+        If row_num is provided, captures the row element when found.
+        Returns tuple: (before_texts, row_element, down_count)
+        """
+        grid_lines = lambda: self.execute_js_selector('tbody tr', self.soup_to_selenium(grid))
+        before_texts = list(filter(lambda x: hasattr(x, 'text'), grid_lines()))
+        before_texts = list(map(lambda x: x.text, before_texts))
+        after_texts = []
+        down_count = 0
+        last_line_selected = False
+        row_element = None
+
+        logger().debug(f"Initial visible lines: {len(before_texts)}")
+
+        if grid_lines():
+            first_line = lambda: next(iter(grid_lines()))
+            last_line = lambda: next(reversed(grid_lines()))
+            
+            # Click first line
+            endtime = time.time() + self.config.time_out  
+            success = False    
+            while endtime > time.time() and not success:
+                self.click(element=first_line(), click_type=enum.ClickType(3))
+                ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
+                success = self.has_selected_cell(row_element=first_line())
+            
+            # Scroll and collect all lines
+            endtime = time.time() + self.config.time_out
+            while endtime > time.time() and \
+                    next(reversed(after_texts), None) != next(reversed(before_texts), None) and \
+                    not last_line_selected:
+
+                after_texts = list(map(lambda x: x.text, grid_lines()))
+
+                for i in after_texts:
+                    if i not in before_texts:
+                        before_texts.append(i)
+
+                # If looking for specific row and found it, capture the element
+                if row_num is not None and len(before_texts) > row_num and row_element is None:
+                    row_element = next(iter(list(filter(lambda x: x.text == before_texts[row_num], grid_lines()))), None)
+                    logger().debug(f"Row found during scroll")
+                    break
+
+                ActionChains(self.driver).key_down(Keys.PAGE_DOWN).perform()
+                down_count += 1
+                self.wait_blocker()
+
+                after_texts = list(map(lambda x: x.text, grid_lines()))
+                last_line_selected = self.has_selected_cell(row_element=last_line())
+
+            ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
+
+        return before_texts, row_element, down_count
+
     def get_obscure_gridline(self, grid, row_num=0):
         """
         [Internal]
@@ -7072,56 +7130,14 @@ class WebappInternal(Base):
         :param row_num:
         :return obscured row based in row number:
         """
-        grid_lines = None
-        row_list = []
-
-        if self.webapp_shadowroot():
-            grid_lines = lambda: self.execute_js_selector('tbody tr', self.soup_to_selenium(grid))
-            before_texts = list(filter(lambda x: hasattr(x, 'text'), grid_lines()))
-            before_texts = list(map(lambda x: x.text, before_texts))
-            after_texts = []
-            down_count = 0
-            last_line_selected = False
-
-            logger().debug(f"Starting search for row {row_num+1}. Initial visible lines: {len(before_texts)}")
-            if grid_lines():
-                first_line = lambda: next(iter(grid_lines()))
-                last_line = lambda: next(reversed(grid_lines()))
-                
-                endtime = time.time() + self.config.time_out  
-                success = False    
-                while endtime > time.time() and not success:
-                    self.click(element=first_line(), click_type=enum.ClickType(3))
-                    ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
-                    success = self.has_selected_cell(row_element=first_line())
-                
-                endtime = time.time() + self.config.time_out                
-                while endtime > time.time() and \
-                        next(reversed(after_texts), None) != next(reversed(before_texts), None) and \
-                        not last_line_selected:
-
-                    after_texts = list(map(lambda x: x.text, grid_lines()))
-
-                    for i in after_texts:
-                        if i not in before_texts:
-                            before_texts.append(i)
-
-                    if len(before_texts) > row_num:
-                        row_list = list(filter(lambda x: x.text == before_texts[row_num], grid_lines()))
-                        logger().debug(f"Row found, ending search")
-                        break
-
-                    ActionChains(self.driver).key_down(Keys.PAGE_DOWN).perform()
-                    down_count += 1
-                    self.wait_blocker()
-
-                    after_texts = list(map(lambda x: x.text, grid_lines()))
-                    last_line_selected = self.has_selected_cell(row_element=last_line())
-                
-                logger().debug(f"Search completed. Total lines collected: {len(before_texts)}, down_count: {down_count}")
-
-            return next(iter(row_list), None), down_count
-
+        logger().debug(f"Starting search for row {row_num+1}")
+        before_texts, row_element, down_count = self._scroll_and_collect_grid_lines(grid, row_num)
+        
+        msg_success = 'Search completed. ' if row_element else f"Row {row_num+1} doesn't found! "
+        msg_success += f"Total lines collected: {len(before_texts)}, down_count: {down_count}"
+        
+        logger().debug(msg_success)
+        return row_element, down_count
 
     def check_grid_memo(self, element):
         """
@@ -9630,55 +9646,13 @@ class WebappInternal(Base):
         Returns the leght of grid.
 
         """
-
-        grid_lines = None
-
         if self.webapp_shadowroot():
-
-            grid_lines = lambda: self.execute_js_selector('tbody tr', self.soup_to_selenium(grid))
-            before_texts = list(filter(lambda x: hasattr(x, 'text'), grid_lines()))
-            before_texts = list(map(lambda x: x.text, before_texts))
-            after_texts = []
-            down_count = 0
-            last_line_selected = False
-
-            logger().debug(f"Starting line count. Initial visible lines: {len(before_texts)}")
-            if grid_lines():
-                first_line = lambda: next(iter(grid_lines()))
-                last_line = lambda: next(reversed(grid_lines()))
-
-                endtime = time.time() + self.config.time_out  
-                success = False    
-                while endtime > time.time() and not success:
-                    self.click(element=first_line(), click_type=enum.ClickType(3))
-                    ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
-                    success = self.has_selected_cell(row_element=first_line())
-                
-                endtime = time.time() + self.config.time_out
-                while endtime > time.time() and \
-                        next(reversed(after_texts), None) != next(reversed(before_texts), None) and \
-                        not last_line_selected:
-
-                    after_texts = list(map(lambda x: x.text, grid_lines()))
-                    for i in after_texts:
-                        if i not in before_texts:
-                            before_texts.append(i)
-
-                    ActionChains(self.driver).key_down(Keys.PAGE_DOWN).perform()
-                    down_count += 1
-                    self.wait_blocker()
-
-                    after_texts = list(map(lambda x: x.text, grid_lines()))
-                    last_line_selected = self.has_selected_cell(row_element=last_line())
-
-                ActionChains(self.driver).key_down(Keys.SHIFT).key_down(Keys.HOME).perform()
-
-                logger().debug(f"Count completed. Total lines: {len(before_texts)}, down_count: {down_count}")
-                return len(before_texts)
+            logger().debug(f"Starting line count")
+            before_texts, _, down_count = self._scroll_and_collect_grid_lines(grid, row_num=None)
+            logger().debug(f"Count completed. Total lines: {len(before_texts)}, down_count: {down_count}")
+            return len(before_texts)
         else:
             return len(grid.select("tbody tr"))
-
-        return len(grid_lines)
 
     def TearDown(self):
         """
@@ -10661,12 +10635,27 @@ class WebappInternal(Base):
         children_classes_before = self.get_active_children_classes(element)
         children_classes_after = children_classes_before
 
-        classes_before = ''
+        classes_before = self.get_selenium_attribute(element(), 'class') if element else ''
         classes_after = classes_before
 
-        if element:
-            classes_before = self.get_selenium_attribute(element(), 'class')
-            classes_after = classes_before
+        loop_check = lambda: ((soup_before_event == soup_after_event) and \
+                              (shadow_roots_before == shadow_roots_after) and \
+                              (parent_classes_before == parent_classes_after) and \
+                              (children_classes_before == children_classes_after) and \
+                              (classes_before == classes_after))
+
+        return_check = lambda: ((soup_before_event != soup_after_event) or \
+                                (shadow_roots_before != shadow_roots_after) or \
+                                (parent_classes_before != parent_classes_after) or \
+                                (children_classes_before != children_classes_after) or \
+                                (classes_before != classes_after))
+        
+        string_debug = lambda: f"Results send_action check:\n" + \
+                               f"soup = {soup_before_event != soup_after_event}\n" + \
+                               f'shadow_roots: {shadow_roots_before != shadow_roots_after}\n' + \
+                               f'parent_classes: {parent_classes_before != parent_classes_after}\n' + \
+                               f'children_classes: {children_classes_before != children_classes_after}\n' + \
+                               f'classes: {classes_before != classes_after}'
 
         self.wait_blocker()
 
@@ -10678,13 +10667,9 @@ class WebappInternal(Base):
 
         endtime = time.time() + self.config.time_out
         try:
-            while ((time.time() < endtime) and \
-                    (soup_before_event == soup_after_event) and \
-                    (shadow_roots_before == shadow_roots_after) and \
-                    (parent_classes_before == parent_classes_after) and \
-                    (children_classes_before == children_classes_after) and \
-                    (classes_before == classes_after) ):
+            while ((time.time() < endtime) and loop_check()):
                 logger().debug(f"Trying to send action")
+
                 if right_click:
                     soup_select = self.get_soup_select(".tmenupopupitem, wa-menu-popup-item")
                     if not soup_select:
@@ -10728,17 +10713,9 @@ class WebappInternal(Base):
             return False
 
         if self.config.smart_test or self.config.debug_log:
-            logger().debug(f"send_action soup = {soup_before_event != soup_after_event}")            
-            logger().debug(f'send_action shadow_roots: {shadow_roots_before != shadow_roots_after}')
-            logger().debug(f'send_action parent_classes: {parent_classes_before != parent_classes_after}')
-            logger().debug(f'send_action children_classes: {children_classes_before != children_classes_after}')
-            logger().debug(f'send_action classes: {classes_before == classes_after}')
+            logger().debug(string_debug())
         
-        return ((soup_before_event != soup_after_event) or \
-                (shadow_roots_before != shadow_roots_after) or \
-                (parent_classes_before != parent_classes_after) or \
-                (children_classes_before != children_classes_after) or \
-                (classes_before != classes_after))
+        return return_check()
 
     def get_selenium_attribute(self, element, attribute):
         try:

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -10670,20 +10670,20 @@ class WebappInternal(Base):
         classes_after = classes_before
 
         loop_check = lambda: ((soup_before_event == soup_after_event) and \
-                              (shadow_roots_before == shadow_roots_after) and \
+                              (sorted(shadow_roots_before) == sorted(shadow_roots_after)) and \
                               (parent_classes_before == parent_classes_after) and \
                               (children_classes_before == children_classes_after) and \
                               (classes_before == classes_after))
 
         return_check = lambda: ((soup_before_event != soup_after_event) or \
-                                (shadow_roots_before != shadow_roots_after) or \
+                                (sorted(shadow_roots_before) != sorted(shadow_roots_after)) or \
                                 (parent_classes_before != parent_classes_after) or \
                                 (children_classes_before != children_classes_after) or \
                                 (classes_before != classes_after))
         
         string_debug = lambda: f"Results send_action check:\n" + \
                                f"soup = {soup_before_event != soup_after_event}\n" + \
-                               f'shadow_roots: {shadow_roots_before != shadow_roots_after}\n' + \
+                               f'shadow_roots: {sorted(shadow_roots_before) != sorted(shadow_roots_after)}\n' + \
                                f'parent_classes: {parent_classes_before != parent_classes_after}\n' + \
                                f'children_classes: {children_classes_before != children_classes_after}\n' + \
                                f'classes: {classes_before != classes_after}'
@@ -10757,48 +10757,40 @@ class WebappInternal(Base):
     def get_shadow_roots_content(self):
         """
         [Internal]
-        Captures the content of all shadow roots in the current DOM.
-        Returns a dictionary with element identifiers and their shadow root HTML.
-        Cleans special characters like \n, \t, and multiple spaces.
+        Captures the innerHTML content of shadow roots from specific elements (wa-tab-page).
+        Returns a list of innerHTML strings for comparison.
+        Cleans special characters like \n, \t, \r and multiple spaces in Python.
         """
         try:
+            shadow_contents = []
+            term = self.grid_selectors["new_web_app"]
+            
+            elements = self.driver.find_elements(By.CSS_SELECTOR, term)
+
             script = """
-            function getShadowRootsContent() {
-                const shadowElements = [];
-                const allElements = document.querySelectorAll('*');
-                
-                allElements.forEach((el, index) => {
-                    if (el.shadowRoot) {
-                        // Get innerHTML and clean special characters
-                        let innerHTML = el.shadowRoot.innerHTML;
-                        // Remove line breaks, tabs, and normalize spaces
-                        innerHTML = innerHTML
-                            .replace(/\\n/g, '')
-                            .replace(/\\t/g, '')
-                            .replace(/\\r/g, '')
-                            .replace(/\\s+/g, ' ')
-                            .trim();
-                        
-                        const elementInfo = {
-                            tagName: el.tagName,
-                            id: el.id || `shadow-${index}`,
-                            className: el.className,
-                            innerHTML: innerHTML
-                        };
-                        shadowElements.push(elementInfo);
-                    }
-                });
-                
-                return JSON.stringify(shadowElements);
+            if (arguments[0].shadowRoot) {
+                return arguments[0].shadowRoot.innerHTML;
             }
-            return getShadowRootsContent();
+            return null;
             """
-            result = self.driver.execute_script(script)
-            return result if result else '[]'
+            
+            # Check each element individually
+            for element in elements:
+                try:
+                    content = self.driver.execute_script(script, element)
+                    if content and self.element_is_displayed(element):
+                        # Clean content
+                        cleaned_content = content.replace('\n', '').replace('\t', '').replace('\r', '').replace('<!---->', '')
+                        cleaned_content = re.sub(r'\s+', ' ', cleaned_content).strip()
+                        shadow_contents.append(cleaned_content)
+                except:
+                    continue
+            
+            return shadow_contents
         except Exception as e:
             if self.config.smart_test or self.config.debug_log:
                 logger().debug(f"Warning Exception get_shadow_roots_content {str(e)}")
-            return '[]'
+            return []
 
     def get_active_parent_class(self, element=None):
         """


### PR DESCRIPTION
# Contexto
A navegação em grids com muitas linhas apresentava inconsistências na coleta completa de conteúdo, principalmente em cenários com PAGE_DOWN/DOWN e mudanças dinâmicas no DOM.

# O que foi alterado

- Refatoração da lógica de scroll/coleta de linhas em grid.
- Melhoria da seleção da primeira linha via select_tr().
- Inclusão de validação de célula selecionada com has_selected_cell().
- Ajustes no fluxo após PAGE_DOWN, com fallback usando DOWN para capturar linhas restantes.
- Melhorias de robustez em checagens de mudança de conteúdo e seleção.
- Ajustes de logs/debug para facilitar diagnóstico.

# Impacto esperado

- Maior estabilidade na leitura de grids longas.
- Redução de falhas intermitentes em testes que dependem de seleção/contagem de linhas.
- Melhor previsibilidade em cenários de virtualização/renderização parcial de linhas.

# Como validar

- Executar cenário com grid extensa (mais linhas do que a área visível).
- Validar que a coleta percorre todas as linhas esperadas.
- Validar que a primeira linha fica corretamente selecionada antes da navegação.
- Validar cenário de busca por linha específica (row_num) durante o scroll.
- Confirmar ausência de regressão nos fluxos de seleção de célula.