### PR TITLE
refactor escape to menu logic for improved success criteria handling

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -1857,20 +1857,29 @@ class WebappInternal(Base):
 
         :return: 
         """
+        success = False
+        container_term = 'wa-dialog'
 
         endtime = time.time() + self.config.time_out /2
-        while time.time() < endtime and self.check_layers('wa-dialog') > 1:
-            if self.check_layers('wa-dialog') > 1:
-                logger().info('Escape to menu')
-                ActionChains(self.driver).send_keys(Keys.ESCAPE).perform()
+        while time.time() < endtime and not success:
+            logger().info('Escape to menu')
+            ActionChains(self.driver).send_keys(Keys.ESCAPE).perform()
 
-            if any([self.check_warning_screen(), self.check_coin_screen(), self.check_news_screen()]):
-                if self.check_layers('wa-dialog') > 1:
-                    logger().info('Found layers after Escape to menu')
-                    self.close_screen_before_menu()
-            # wait trasitions between screens to avoid errors in layers number
-            self.wait_element_timeout(term='wa-dialog', scrap_type=enum.ScrapType.CSS_SELECTOR,
-                                      position=2, timeout=6, main_container='body')
+            menu_screen = self.check_tmenu_screen()
+            container_layers = self.check_layers(container_term) == 1
+            success = menu_screen and container_layers
+
+            logger().info(f'Check Menu Screen: {menu_screen}')
+            logger().info(f'wa-dialog layers: {container_layers}')
+
+        if any([self.check_warning_screen(), self.check_coin_screen(), self.check_news_screen()]) \
+           and self.check_layers(container_term) > 1:
+            logger().info('Found layers after Escape to menu')
+            self.close_screen_before_menu()
+        
+        # wait trasitions between screens to avoid errors in layers number
+        self.wait_element_timeout(term=container_term, scrap_type=enum.ScrapType.CSS_SELECTOR,
+                                    position=2, timeout=6, main_container='body')
 
     def check_layers(self, term):
         """


### PR DESCRIPTION
Agora a função escape_to_main_menu,
Primeiro espera estar na home usando os critérios ter apenas 1 elemento wa-dialog E ter algum elemento específico da home, essa alteração foi feita pois estava dando falso positivo apenas o critério de ter 1 elemento wa-dialog.
Os outros processos foram removidos do while por conta que precisam ser executados apenas uma vez.