### PR TITLE
Hotfix/set lateral menu fix loop timeout

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -4318,16 +4318,16 @@ class WebappInternal(Base):
                     expanded = lambda: 'expanded' in submenu().get_attribute('class')
                     item_exist = lambda: self.element_exists(term=menuitem, scrap_type=enum.ScrapType.MIXED,
                                                              optional_term=menu_itens_term,
-                                                             main_container="body, wa-dialog")
+                                                             main_container="body, wa-dialog") and self.check_tmenu_screen()
                     tmodal = lambda: self.get_current_DOM().select('.tmodaldialog')
 
                     endtime = time.time() + self.config.time_out
 
                     clicked_menu = False
 
-                    while (time.time() < endtime and not clicked_menu and (
+                    while (time.time() < endtime and (
                             (index != last_index and not expanded()) or
-                            (index == last_index and item_exist() and not tmodal()))):
+                            ((index == last_index and item_exist() and not tmodal()) and not clicked_menu))):
                         if click_menu_functional:
                             clicked_menu = True
                         ActionChains(self.driver).move_to_element(submenu()).click().perform()

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -4325,9 +4325,10 @@ class WebappInternal(Base):
 
                     clicked_menu = False
 
-                    while (time.time() < endtime and (
-                            (index != last_index and not expanded()) or
-                            ((index == last_index and item_exist() and not tmodal()) and not clicked_menu))):
+                    while time.time() < endtime and not clicked_menu and (
+                        (index != last_index and not expanded()) or 
+                        (index == last_index and item_exist() and not tmodal())
+                    ):
                         if click_menu_functional:
                             clicked_menu = True
                         ActionChains(self.driver).move_to_element(submenu()).click().perform()

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -4325,8 +4325,9 @@ class WebappInternal(Base):
 
                     clicked_menu = False
 
-                    while time.time() < endtime and (index != last_index and not expanded()) or (
-                            index == last_index and item_exist() and not tmodal()) and not clicked_menu:
+                    while (time.time() < endtime and not clicked_menu and (
+                            (index != last_index and not expanded()) or
+                            (index == last_index and item_exist() and not tmodal()))):
                         if click_menu_functional:
                             clicked_menu = True
                         ActionChains(self.driver).move_to_element(submenu()).click().perform()


### PR DESCRIPTION
Ajustei a lógica do while para garantir que o timeout (endtime) interrompa o loop imediatamente, corrigindo casos onde a automação ficava presa em looping infinito. Também atualizei a função item_exist: agora ela só retorna verdadeiro se o texto do item for encontrado e se a automação ainda estiver na tela "home".