### PR TITLE
get po-tag

### DIFF
--- a/tir/technologies/core/language.py
+++ b/tir/technologies/core/language.py
@@ -93,6 +93,7 @@ class LanguagePack:
 
         self.filters = languagepack["Filters"]
         self.apply_filters = languagepack["Apply Filters"]
+        self.remove_filters = languagepack["Remove Filters"]
         self.old_browse_edit = languagepack["Old Browse Edit"]
         self.old_browse_delete = languagepack["Old Browse Delete"]
         self.old_browse_insert = languagepack["Old Browse Insert"]
@@ -204,6 +205,7 @@ class LanguagePack:
             "New Home Menu About": "About",
             "Filters": "Filters",
             "Apply Filters": "Apply filters",
+            "Remove Filters": "Remove filters",
 
             "Old Browse Edit":"Edit",
             "Old Browse Delete":"Delete",
@@ -311,7 +313,8 @@ class LanguagePack:
             "Input Set Program": "Pesquisar e executar",
             "New Home Menu About": "Sobre",
             "Filters": "Filtros",
-            "Apply Filters": "Aplicar Filtros",            
+            "Apply Filters": "Aplicar Filtros",
+            "Remove Filters": "Remover filtros",
 
             "Old Browse Edit":"Alterar",
             "Old Browse Delete":"Excluir",
@@ -418,7 +421,8 @@ class LanguagePack:
             "Input Set Program": "Buscar y ejecutar",
             "New Home Menu About": "Sobre",
             "Filters": "Filtros",
-            "Apply Filters": "Aplicar Filtros",            
+            "Apply Filters": "Aplicar Filtros",
+            "Remove Filters": "Eliminar filtros",
             "Old Browse Edit":"Modificar",
             "Old Browse Delete":"Borrar",
             "Old Browse Insert":"Incluir",
@@ -525,6 +529,9 @@ class LanguagePack:
             "Schedule Menu": "Settings > Schedule > Schedule",
             "Input Set Program": "Ищи и беги",
             "New Home Menu About": "О программе…",
+            "Filters": "Фильтры",
+            "Apply Filters": "Применить фильтры",
+            "Remove Filters": "Удалить фильтры",
 
             "Old Browse Edit":"Редактировать",
             "Old Browse Delete":"Удалить",

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5637,8 +5637,8 @@ class PouiInternal(Base):
         [Internal]
         Open and apply filters to each field in a THF Browse component.
 
-        :param filters: Dictionary or list of filters to apply, where keys are field names and values are filter values.
-        :type filters: dict or list
+        :param filters: List of dictionaries representing filters to apply, where each dictionary's keys are field names and values are filter values.
+        :type filters: list
         :param browse_div: BeautifulSoup object representing the browse container element.
         :type browse_div: bs4.element.Tag
         :return: None
@@ -5647,8 +5647,10 @@ class PouiInternal(Base):
         Usage:
 
         >>> # Calling the method:
-        >>> self._filter_thf_browse(filters={'name': 'John'}, browse_div=browse_element)
+        >>> self._filter_thf_browse(filters=[{'name': 'John'}], browse_div=browse_element)
         """
+
+        self._remove_filters_from_browse()
 
         self.click_button(self.language.filters)
 
@@ -5681,6 +5683,67 @@ class PouiInternal(Base):
                     self._fill_filter_input(input_element, value)
 
         self.click_button(self.language.apply_filters)
+
+
+    def _remove_filters_from_browse(self):
+        """
+        [Internal]
+
+        Clicks the "Remove Filters" button in a THF Browse component to clear all applied filters.
+        Also checks for a po-tag element inside kendo-grid whose span text is
+        "Remover filtros" or "Remove filters", and clicks it when found.
+
+        :return: None
+        :rtype: None
+
+        Usage:
+
+        >>> # Calling the method:
+        >>> self._remove_filters_from_browse()
+        """
+
+        po_tag_filter = self._get_po_tag(text=self.language.remove_filters, container_selector='kendo-grid')
+        if po_tag_filter:
+            logger().debug("Found applied filters, clicking to remove filters.")
+            clickable = po_tag_filter.select_one('.po-tag-wrapper.po-clickable')
+            target = clickable if clickable else po_tag_filter
+            self.poui_click(target)
+            self.po_loading(self.containers_selectors['GetCurrentContainer'])
+        else:
+            logger().debug("No 'Remove Filters' found; skipping filter removal.")
+
+
+    def _get_po_tag(self, text: str, container_selector: str):
+        """
+        [Internal]
+
+        Searches for a po-tag element inside a specified container whose span text matches
+        the given text (case-insensitive).
+
+        :param text: Text to match inside the po-tag span.
+        :type text: str
+        :param container_selector: CSS selector for the container to search within.
+        :type container_selector: str
+        :return: The matching po-tag BeautifulSoup element, or None if not found.
+        :rtype: bs4.element.Tag or None
+        """
+
+        soup = self.get_current_DOM(twebview=True)
+        if container_selector:
+            container = soup.select_one(container_selector)
+        else:
+            container = soup
+
+        if not container:
+            logger().debug(f"No container found in DOM when searching for po-tag filter with selector '{container_selector}'.")
+            return None
+
+        for po_tag in container.select('po-tag'):
+            span = po_tag.select_one('.po-tag-value span')
+            if span and span.text.strip().lower() == text.strip().lower():
+                return po_tag
+
+        return None
 
 
     def _fill_lookup_input(self, input_element, value: str) -> None:


### PR DESCRIPTION
## Description

Adds support for removing previously applied filters in the THF Browse component before applying new ones. Introduces a reusable `po-tag` DOM utility and extends the language pack with the new "Remove Filters" key across all supported languages.

---

## Changes

### `tir/technologies/core/language.py`
- Added `remove_filters` attribute to `LanguagePack` class.
- Mapped the key to localized strings for all supported languages:
  - **English:** "Remove filters"
  - **Portuguese:** "Remover filtros"
  - **Spanish:** "Eliminar filtros"
  - **Russian:** "Удалить фильтры"
- Also added missing `Filters` and `Apply Filters` entries for the **Russian** language pack.

### `tir/technologies/poui_internal.py`
- **`_filter_thf_browse`**: Now calls `_remove_filters_from_browse()` before opening the filter panel, ensuring stale filters are cleared prior to applying new ones. Updated docstring to reflect that `filters` must be a `list` of dicts.
- **`_remove_filters_from_browse`** *(new)*: Checks for a `po-tag` element inside `kendo-grid` matching the "Remove Filters" label and clicks it when found, then waits for the component to finish loading.
- **`_get_po_tag`** *(new)*: Generic DOM helper that locates a `po-tag` element within a given CSS-selector container by matching its inner `span` text (case-insensitive). Returns the element or `None`.

---

## Motivation

When `_filter_thf_browse` was called multiple times, previously applied filters remained active, causing incorrect or cumulative filter results. This fix ensures a clean state before each filter application.

---

## Testing

- [ ] Verify that filters are correctly removed before new filters are applied in THF Browse.
- [ ] Validate that `_get_po_tag` returns the correct element when a matching `po-tag` exists.
- [ ] Validate that `_get_po_tag` returns `None` when no matching element is found.
- [ ] Confirm all language strings render correctly for EN, PT, ES, and RU locales.
- [ ] Ensure no regression in existing filter-related tests.

---

## Related Issues / Tickets
