### PR TITLE
Enhance loading state logging and refactor related methods

### DIFF
--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3748,18 +3748,10 @@ class PouiInternal(Base):
 
         logger().info("Waiting loading...")
 
-        loading = True
+        main_container = selector or 'body'
 
-        endtime = time.time() + 300
-        while loading and time.time() < endtime:
-            if selector:
-                container = self.web_scrap(term=selector, scrap_type=enum.ScrapType.CSS_SELECTOR,
-                                        main_container='body')
-            else:
-                container = self.get_current_DOM(twebview=True)
-                container = [container]
-                
-            loading = True if list(filter(lambda x: x.select('po-loading'), container)) else False
+        self.wait_element(term='po-loading', scrap_type=enum.ScrapType.CSS_SELECTOR, 
+                          presence=False, main_container=main_container)
 
         logger().info("Loading finished!")
         

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3740,10 +3740,27 @@ class PouiInternal(Base):
         if hasattr(element.find_parent('div', {'tabindex': '-1'}), 'attr'):
             return element if element.find_parent('div', {'tabindex': '-1'}) else None
 
-    def po_loading(self, selector=''):
+    def _po_loading(self, selector: str = '') -> None:
         """
-
-        :return:
+        [Internal]
+        
+        Waits for po-loading component to disappear, indicating that the page loading is complete.
+        
+        Searches within a specified container (or entire body if not specified) and waits for 
+        the po-loading element to be absent from the DOM.
+        
+        :param selector: CSS selector of the container to monitor. If empty, searches entire body. - **Default:** '' (empty string)
+        :type selector: str
+        
+        :return: None
+        :rtype: None
+        
+        Usage:
+        
+        >>> # Wait for loading to complete in entire page
+        >>> self._po_loading()
+        >>> # Wait for loading to complete within a specific dialog
+        >>> self._po_loading('wa-dialog')
         """
 
         logger().info("Waiting loading...")
@@ -4504,7 +4521,7 @@ class PouiInternal(Base):
 
         table_number -= 1
 
-        self.po_loading()
+        self._po_loading()
 
         self.wait_element(term=selector, scrap_type=enum.ScrapType.CSS_SELECTOR)
 
@@ -5365,7 +5382,7 @@ class PouiInternal(Base):
                                                     main_container='body')), None)
             
             self.InputValue(self.language.input_set_program, program_name or program_desc, 1, exec_enter_tab=False)
-            self.po_loading(self.containers_selectors['GetCurrentContainer'])
+            self._po_loading()
             if not program_name and program_desc:
                 self.config.routine = self._get_program_by_desc(program_desc)
             self.click_po_list_box(value=program_desc, second_value=program_name, program_call=True)
@@ -5653,7 +5670,7 @@ class PouiInternal(Base):
         >>> self._filter_thf_browse(filters=[{'name': 'John'}], browse_div=browse_element)
         """
 
-        self.po_loading()
+        self._po_loading()
 
         self._remove_filters_from_browse()
 
@@ -5721,7 +5738,7 @@ class PouiInternal(Base):
             clickable = po_tag_filter.select_one('.po-tag-wrapper.po-clickable')
             target = clickable if clickable else po_tag_filter
             self.poui_click(target)
-            self.po_loading(self.containers_selectors['GetCurrentContainer'])
+            self._po_loading()
         else:
             logger().debug("No 'Remove Filters' found; skipping filter removal.")
 
@@ -5926,7 +5943,7 @@ class PouiInternal(Base):
         :type check_error: bool
         """
 
-        self.po_loading()
+        self._po_loading()
 
         button_normalized = str(button).lower().strip() if button is not None else ""
         sub_item_normalized = str(sub_item).lower().strip() if sub_item is not None else ""

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5923,7 +5923,6 @@ class PouiInternal(Base):
         :type check_error: bool
         """
 
-        logger().info("Switching to the POUI button-click method")
         button_normalized = str(button).lower().strip() if button is not None else ""
         sub_item_normalized = str(sub_item).lower().strip() if sub_item is not None else ""
 

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3740,7 +3740,7 @@ class PouiInternal(Base):
         if hasattr(element.find_parent('div', {'tabindex': '-1'}), 'attr'):
             return element if element.find_parent('div', {'tabindex': '-1'}) else None
 
-    def po_loading(self, selector):
+    def po_loading(self, selector=''):
         """
 
         :return:
@@ -3752,9 +3752,13 @@ class PouiInternal(Base):
 
         endtime = time.time() + 300
         while loading and time.time() < endtime:
-            container = self.web_scrap(term=selector, scrap_type=enum.ScrapType.CSS_SELECTOR,
-                                       main_container='body')
-
+            if selector:
+                container = self.web_scrap(term=selector, scrap_type=enum.ScrapType.CSS_SELECTOR,
+                                        main_container='body')
+            else:
+                container = self.get_current_DOM(twebview=True)
+                container = [container]
+                
             loading = True if list(filter(lambda x: x.select('po-loading'), container)) else False
 
         logger().info("Loading finished!")
@@ -4508,7 +4512,7 @@ class PouiInternal(Base):
 
         table_number -= 1
 
-        self.po_loading(selector='wa-dialog')
+        self.po_loading()
 
         self.wait_element(term=selector, scrap_type=enum.ScrapType.CSS_SELECTOR)
 
@@ -5657,7 +5661,7 @@ class PouiInternal(Base):
         >>> self._filter_thf_browse(filters=[{'name': 'John'}], browse_div=browse_element)
         """
 
-        self.po_loading(selector='wa-dialog')
+        self.po_loading()
 
         self._remove_filters_from_browse()
 
@@ -5930,7 +5934,7 @@ class PouiInternal(Base):
         :type check_error: bool
         """
 
-        self.po_loading(selector='wa-dialog')
+        self.po_loading()
 
         button_normalized = str(button).lower().strip() if button is not None else ""
         sub_item_normalized = str(sub_item).lower().strip() if sub_item is not None else ""

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3745,6 +3745,9 @@ class PouiInternal(Base):
 
         :return:
         """
+
+        logger().info("Waiting loading...")
+
         loading = True
 
         endtime = time.time() + 300
@@ -3754,6 +3757,8 @@ class PouiInternal(Base):
 
             loading = True if list(filter(lambda x: x.select('po-loading'), container)) else False
 
+        logger().info("Loading finished!")
+        
     def click_select(self, field, value, position):
         """
         

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5657,6 +5657,8 @@ class PouiInternal(Base):
         >>> self._filter_thf_browse(filters=[{'name': 'John'}], browse_div=browse_element)
         """
 
+        self.po_loading(selector='wa-dialog')
+
         self._remove_filters_from_browse()
 
         self.click_button(self.language.filters)
@@ -5927,6 +5929,8 @@ class PouiInternal(Base):
         :param check_error: Whether to check for errors - **Default:** True
         :type check_error: bool
         """
+
+        self.po_loading(selector='wa-dialog')
 
         button_normalized = str(button).lower().strip() if button is not None else ""
         sub_item_normalized = str(sub_item).lower().strip() if sub_item is not None else ""

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -2173,19 +2173,9 @@ class WebappInternal(Base):
             return
 
     def _is_new_browse(self, throw_error=True, timeout=None):
-        
         browse_div = self._find_search_browse(throw_error=throw_error, timeout=timeout)
 
-        if browse_div and browse_div.name == 'thf-grid':
-            logger().info("Switching to the POUI method")
-            logger().info("Waiting loading...")
-            self.wait_element(term='po-loading', scrap_type=enum.ScrapType.CSS_SELECTOR, presence=False, main_container="body", twebview=True)
-            logger().info("Loading finished!")
-
-            return True
-        
-        else:
-            return False
+        return browse_div.name == 'thf-grid' if browse_div else False
 
     def longest_word(self, string):
         words = string.split()

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -2172,12 +2172,20 @@ class WebappInternal(Base):
             self.log_error(f"_simple_search_thf_browse: couldn't fill search input with value '{search_text}'")
             return
 
-
     def _is_new_browse(self, throw_error=True, timeout=None):
+        
         browse_div = self._find_search_browse(throw_error=throw_error, timeout=timeout)
 
-        return browse_div.name == 'thf-grid' if browse_div else False
+        if browse_div and browse_div.name == 'thf-grid':
+            logger().info("Switching to the POUI method")
+            logger().info("Waiting loading...")
+            self.wait_element(term='po-loading', scrap_type=enum.ScrapType.CSS_SELECTOR, presence=False, main_container="body", twebview=True)
+            logger().info("Loading finished!")
 
+            return True
+        
+        else:
+            return False
 
     def longest_word(self, string):
         words = string.split()


### PR DESCRIPTION
# Refatoração: Consolidação e Melhoria do Método `po_loading()`

## Resumo

Este PR refatora o método interno `_po_loading()` para consolidar o tratamento de estado de carregamento em toda a estrutura POUI, introduzindo melhorias arquiteturais e documentação.

## Objetivos

- **Separação de Responsabilidades**: Extrair a lógica de espera de carregamento de métodos de detecção para métodos de ação dedicados
- **Consolidação de Código**: Substituir loops de espera customizados pelo mecanismo centralizado `wait_element()` da framework
- **Clareza da API Interna**: Marcar método como interno com prefixo `_` para evitar uso externo
- **Documentação**: Fornecer docstring abrangente com exemplos e documentação de parâmetros

## Mudanças Realizadas

### 1. Refatoração da Assinatura e Implementação do Método

- Adicionado prefixo `_` para indicar método interno
- Adicionadas type hints: `selector: str = ''` e tipo de retorno `-> None`
- Substituído loop customizado pelo `wait_element()` consolidado da framework
- Seletor agora é opcional com padrão sensato (fallback para `'body'`)
- Integrada estratégia inteligente de backoff do `wait_element()`
- Adicionado logging para observabilidade

### 2. Locais de Chamada Atualizados (6 locações)

#### a. `return_table()` - Linha 4524
```diff
- self.po_loading(selector='wa-dialog')
+ self._po_loading()
```
Justificativa: Removido seletor hardcoded; agora usa escopo padrão (corpo inteiro)

#### b. `_set_browse_program()` - Linha 5385
```diff
- self.po_loading(self.containers_selectors['GetCurrentContainer'])
+ self._po_loading()
```
Justificativa: Simplificado para comportamento padrão após busca de container dinâmico

#### c. `_filter_thf_browse()` - Linha 5673 (NOVA CHAMADA)
```diff
+ self._po_loading()
```
Justificativa: Adicionada espera de carregamento no início do método para tratar mudanças dinâmicas na UI de filtragem

#### d. `_remove_filters_from_browse()` - Linha 5741
```diff
- self.po_loading(self.containers_selectors['GetCurrentContainer'])
+ self._po_loading()
```
Justificativa: Consolidado para comportamento padrão por consistência

#### e. `SetButton()` - Linha 5946 (MOVIDO)
```diff
+ self._po_loading()
```
Justificativa: Movida espera de carregamento para ponto de entrada do método; agora aguarda antes da interação com botão

### 3. Aprimoramento da Documentação

Adicionada docstring abrangente com:
- Tag `[Internal]` para clareza
- Explicação clara do propósito
- Documentação de parâmetro com valores padrão
- Especificação de tipo de retorno
- Dois exemplos de uso (genérico e baseado em seletor)

**Exemplos de Uso:**
```python
>>> # Aguardar carregamento completo em toda a página
>>> self._po_loading()
>>> # Aguardar carregamento completo em um diálogo específico
>>> self._po_loading('wa-dialog')
```

## Recomendações de Teste

1. Comportamento Padrão: Testar `_po_loading()` sem seletor em páginas com po-loading
2. Espera Delimitada: Testar com parâmetro seletor em diálogos com po-loading
3. Cenário de Timeout: Verificar se framework lança erro se po-loading não desaparecer dentro do timeout
4. Integração: Confirmar que SetButton, _filter_thf_browse, return_table funcionam com a nova implementação