### PR TITLE
Filter non-displayed labels in labels_list_filtered

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -2818,6 +2818,8 @@ class WebappInternal(Base):
                 else:
                     labels_list_filtered = list(filter(lambda x: 'th' not in self.element_name(x.parent.parent) , view_filtred))
 
+                labels_list_filtered = list(filter(lambda x: self.element_is_displayed(x), labels_list_filtered))
+                
                 if labels_list_filtered and len(labels_list_filtered) -1 >= position:
                     label = labels_list_filtered[position]
 


### PR DESCRIPTION
# Título

Filtra apenas labels visíveis em `search_element_position()`

# Descrição

Este PR ajusta o filtro de labels para considerar somente elementos visíveis antes de selecionar o item por posição.
O problema foi identificado na rotina MATA122 (Argentina), onde a tela tinha dois campos "Gastos" (um visível e outro oculto) e o código não fazia esse filtro, ocasionando a seleção do campo errado.
A mudança é pequena e focada em evitar erro em uma tela específica, sem alterar o fluxo principal da função.

# Impacto esperado

- Evita seleção de labels ocultas.
- Mantém o comportamento atual de busca e posição para elementos visíveis.

# Validação

- Executado fluxo da tela com erro anterior.
- Sem regressão observada nos cenários já existentes.
