### PR TITLE
Refactor click method to use enum.ClickType.SELENIUM for consistency

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -5689,7 +5689,7 @@ class WebappInternal(Base):
             elif click_type == 2:
                 self.double_click(element(), click_type=enum.ClickType.ACTIONCHAINS)
             elif click_type == 3:
-                element().click()
+                self.click(element(), enum.ClickType.SELENIUM)
                 ActionChains(self.driver).move_to_element(element()).send_keys(Keys.ENTER).perform()
             elif click_type == 4:
                 self.send_action(action=self.double_click, element=element, wait_change=False)


### PR DESCRIPTION
## Descrição

Ajuste do método de clique no evento `click_type == 3` para utilizar o método `self.click()` com `enum.ClickType.SELENIUM` em vez de chamar diretamente `element().click()`.

## Objetivo

Anteriormente, quando um clique era realizado diretamente via `element().click()`, erros não tratados causavam uma exceção que interrompia o fluxo sem permite pressionar Enter. Agora, o erro é tratado dentro do método `self.click()`, garantindo que o fluxo continue e a tecla Enter seja pressionada corretamente.

## Mudança

- **Antes:** `element().click()` - chamada direta sem tratamento de erro
- **Depois:** `self.click(element(), enum.ClickType.SELENIUM)` - utiliza o método interno com tratamento de erro

Este ajuste melhora a robustez do código e garante consistência com os demais tipos de clique utilizados nesta seção do código.