### PR TITLE
Add entrypoint context to script messages in WebappInternal class

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -9339,6 +9339,11 @@ class WebappInternal(Base):
 
             self.expected = not self.expected
 
+        if not self.errors and script_message:
+            entrypoint_function = self.utils.get_main_entrypoint_from_stack()
+            entrypoint = f"[{entrypoint_function}] " if entrypoint_function and entrypoint_function != "function_name" else ""
+            script_message = entrypoint + script_message
+
         if self.expected:
             self.message = "" if not self.errors else log_message
             self.log.new_line(True, self.message)


### PR DESCRIPTION
Ajustando mensagem de erro do AssertTrue/AssertFalse para aparecer o nome do método principal.