### PR TITLE
Enhance routing and case sensitivity in ClickCombo and methods

### DIFF
--- a/tir/main.py
+++ b/tir/main.py
@@ -485,11 +485,14 @@ class Webapp():
 
         :param program_name: The program name
         :type program_name: str
+        :param module: Module abbreviation used to differentiate routines with the same name. - **Default:** "" (empty string)
+        :type module: str
 
         Usage:
 
         >>> # Calling the method:
         >>> oHelper.Program("MATA020")
+        >>> oHelper.Program("CRDA200", module="CRD")
         """
         self.__router.Program(program_name=program_name, module=module)
 
@@ -794,13 +797,22 @@ class Webapp():
         Navigates through the lateral menu using provided menu path.
         e.g. "MenuItem1 > MenuItem2 > MenuItem3"
 
-        :param menu_itens: String with the path to the menu.
-        :type menu_itens: str
+        :param menuitens: String with the path to the menu.
+        :type menuitens: str
+        :param save_input: Keeps compatibility with WebApp lateral menu behavior. - **Default:** True
+        :type save_input: bool
+        :param click_menu_functional: Uses functional menu click strategy in WebApp. - **Default:** False
+        :type click_menu_functional: bool
+        :param program_name: Program name to be used in New Home (POUI) when routine descriptions are duplicated. - **Default:** "" (empty string)
+        :type program_name: str
+        :param module: Module abbreviation used to differentiate routines with the same name in New Home (POUI). - **Default:** "" (empty string)
+        :type module: str
 
         Usage:
 
         >>> # Calling the method:
         >>> oHelper.SetLateralMenu("Updates > Registers > Products > Groups")
+        >>> oHelper.SetLateralMenu("Updates > Registers > Products > Groups", program_name="CRDA200", module="CRD")
         """
         self.__router.SetLateralMenu(menuitens, save_input, click_menu_functional, 
                                      program_name=program_name, module=module)
@@ -2284,7 +2296,7 @@ class Poui():
 
         self.__poui.click_switch(label=label, value=value, position=position)
 
-    def Program(self, program_name, module: str = ''):
+    def Program(self, program_name: str = '', module: str = ''):
         """
         Method that sets the program in the initial menu search field.
 
@@ -2293,13 +2305,16 @@ class Poui():
 
         :param program_name: The program name
         :type program_name: str
+        :param module: Module abbreviation used to differentiate routines with the same name. - **Default:** "" (empty string)
+        :type module: str
 
         Usage:
 
         >>> # Calling the method:
         >>> oHelper.Program("MATA020")
+        >>> oHelper.Program("CRDA200", module="CRD")
         """
-        self.__poui.Program(program_name, module=module)
+        self.__poui.Program(program_name=program_name, module=module)
     
 
     def ClickDropdown(self, label='', subitems='', position=1):

--- a/tir/main.py
+++ b/tir/main.py
@@ -1777,7 +1777,7 @@ class Poui():
         """
         self.__poui.InputValue(field, value, position)
 
-    def ClickCombo(self, field='', value='', position=1, second_value=''):
+    def ClickCombo(self, field='', value='', position=1, second_value='', match_case=True):
         """
         Clicks on the Combo of POUI component.
         https://po-ui.io/documentation/po-combo
@@ -1785,6 +1785,10 @@ class Poui():
         :param field: Combo text title that you want to click.
         :param value: Value that you want to select in Combo.
         :param position: Position which element is located. - **Default:** 1
+        :param second_value: Secondary value displayed below the main value. - **Default:** "" (empty string)
+        :type second_value: str
+        :param match_case: If True, requires exact normalized match; if False, allows partial normalized match. - **Default:** True
+        :type match_case: bool
 
         Usage:
 
@@ -1792,7 +1796,7 @@ class Poui():
         >>> oHelper.ClickCombo('Visão', 'Compras')
         :return:
         """
-        self.__poui.click_combo(field, value, position, second_value)
+        self.__poui.click_combo(field, value, position, second_value, match_case)
 
     def ClickSelect(self, field='', value='', position=1):
         """

--- a/tir/main.py
+++ b/tir/main.py
@@ -476,7 +476,7 @@ class Webapp():
         """
         self.__webapp.MessageBoxClick(button_text)
 
-    def Program(self, program_name):
+    def Program(self, program_name: str, module: str = ''):
         """
         Method that sets the program in the initial menu search field.
 
@@ -491,7 +491,7 @@ class Webapp():
         >>> # Calling the method:
         >>> oHelper.Program("MATA020")
         """
-        self.__router.Program(program_name)
+        self.__router.Program(program_name=program_name, module=module)
 
     def RestoreParameters(self):
         """
@@ -788,7 +788,8 @@ class Webapp():
         """
         self.__webapp.SetKey(key, grid, grid_number,additional_key, wait_show, step, wait_change)
 
-    def SetLateralMenu(self, menuitens, save_input=True, click_menu_functional=False):
+    def SetLateralMenu(self, menuitens, save_input=True, click_menu_functional=False, 
+                       program_name:str = '', module: str = ''):
         """
         Navigates through the lateral menu using provided menu path.
         e.g. "MenuItem1 > MenuItem2 > MenuItem3"
@@ -801,7 +802,8 @@ class Webapp():
         >>> # Calling the method:
         >>> oHelper.SetLateralMenu("Updates > Registers > Products > Groups")
         """
-        self.__router.SetLateralMenu(menuitens, save_input, click_menu_functional)
+        self.__router.SetLateralMenu(menuitens, save_input, click_menu_functional, 
+                                     program_name=program_name, module=module)
 
     def SetParameters(self):
         """
@@ -2282,7 +2284,7 @@ class Poui():
 
         self.__poui.click_switch(label=label, value=value, position=position)
 
-    def Program(self, program_name):
+    def Program(self, program_name, module: str = ''):
         """
         Method that sets the program in the initial menu search field.
 
@@ -2297,7 +2299,7 @@ class Poui():
         >>> # Calling the method:
         >>> oHelper.Program("MATA020")
         """
-        self.__poui.Program(program_name)
+        self.__poui.Program(program_name, module=module)
     
 
     def ClickDropdown(self, label='', subitems='', position=1):

--- a/tir/technologies/core/config.py
+++ b/tir/technologies/core/config.py
@@ -131,6 +131,7 @@ class ConfigLoader:
             self.sso_login = ("SSOLogin" in data and bool(data["SSOLogin"]))
             self.new_home = ("NewHome" in data and bool(data["NewHome"]))
             self._flag_is_new_browse = None
+            self.routine_module = ""
 
 
     def check_keys(self, json_data):

--- a/tir/technologies/core/router.py
+++ b/tir/technologies/core/router.py
@@ -87,11 +87,16 @@ class Router:
 
         return self._ensure_poui() if condition_fn() else self._ensure_webapp()
 
-    def Program(self, program_name: str = "", program_desc: str = "") -> None:
+    def Program(self, program_name: str = "", module: str = '') -> None:
         """Execute program using appropriate driver (POUI or WebApp)."""
 
         drv = self._get_driver_instance(lambda: self.config.new_home)
-        drv.Program(program_name=program_name, program_desc=program_desc)
+        if not self.config.new_home:
+            # webapp
+            drv.Program(program_name=program_name)
+        else:
+            # poui
+            drv.Program(program_name=program_name, module=module)
 
         """
         Sync POUI → WebApp program name (new_home):
@@ -109,11 +114,19 @@ class Router:
         drv = self._get_driver_instance(lambda: self.config.new_home)
         drv.set_program(program_name=program_name, program_desc=program_desc)
 
-    def SetLateralMenu(self, menu_itens: str, save_input: bool = True, click_menu_functional: bool = False) -> None:
+    def SetLateralMenu(self, menu_itens: str, save_input: bool = True, click_menu_functional: bool = False, 
+                       program_name:str = '', module: str = '') -> None:
         """Navigate through lateral menu."""
 
         drv = self._get_driver_instance(lambda: self.config.new_home)
-        drv.SetLateralMenu(menu_itens=menu_itens, save_input=save_input, click_menu_functional=click_menu_functional)
+        if not self.config.new_home:
+            # webapp
+            drv.SetLateralMenu(menu_itens=menu_itens, save_input=save_input, 
+                               click_menu_functional=click_menu_functional)
+        else:
+            # poui
+            drv.SetLateralMenu(menu_itens=menu_itens, program_name=program_name, 
+                               module=module)
 
     def ChangeEnvironment(self, date: str = "", group: str = "", branch: str = "", module: str = "") -> None:
         """Change environment settings."""

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -1664,7 +1664,7 @@ class PouiInternal(Base):
             
             if self.config.routine:
                 if self.config.routine_type.lower() == 'setlateralmenu':
-                    self.SetLateralMenu(self.config.routine, save_input=False)
+                    self.SetLateralMenu(self.config.routine)
                 elif self.config.routine_type.lower() == 'program':
                     self.set_program(self.config.routine, self.config.routine_module)
 
@@ -5321,13 +5321,18 @@ class PouiInternal(Base):
 
         Method that sets the program in the initial menu search field on New Home.
 
-        :param program: The program name
-        :type program: str
+        :param program_name: Program code to search/execute. - **Default:** "" (empty string)
+        :type program_name: str
+        :param program_desc: Program description used as fallback when `program_name` is not provided. - **Default:** "" (empty string)
+        :type program_desc: str
+        :param module: Module abbreviation used to differentiate routines with the same name. - **Default:** "" (empty string)
+        :type module: str
 
         Usage:
 
         >>> # Calling the method:
-        >>> self.set_program_new_home("MATA020")
+        >>> self.Program("MATA020")
+        >>> self.Program("CRDA200", module="CRD")
         """
 
         self.config.routine_type = 'Program'
@@ -5354,7 +5359,7 @@ class PouiInternal(Base):
         search_term = "[class*='card-wrapper']"
         confirm_term = f"wa-button[caption='{self.language.confirm}']"
         attempts = 1
-        program_with_module = f'{program_name} - {module}' if module else None
+        program_with_module = f'{program_name} - {module}' if program_name and module else None
 
         self.escape_to_main_menu()
 
@@ -5528,6 +5533,15 @@ class PouiInternal(Base):
 
 
     def SetLateralMenu(self, menu_itens: str, program_name:str = '', module: str = '') -> None:        
+        """Navigate through New Home menu context and open a routine.
+
+        :param menu_itens: Menu path used as fallback to derive the routine description.
+        :type menu_itens: str
+        :param program_name: Program code to execute when provided. - **Default:** "" (empty string)
+        :type program_name: str
+        :param module: Module abbreviation used to differentiate routines with the same name. - **Default:** "" (empty string)
+        :type module: str
+        """
         
         if not program_name:
             logger().warning(

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -1666,7 +1666,7 @@ class PouiInternal(Base):
                 if self.config.routine_type.lower() == 'setlateralmenu':
                     self.SetLateralMenu(self.config.routine, save_input=False)
                 elif self.config.routine_type.lower() == 'program':
-                    self.set_program(self.config.routine)
+                    self.set_program(self.config.routine, self.config.routine_module)
 
     def driver_refresh(self):
         """
@@ -5259,7 +5259,7 @@ class PouiInternal(Base):
             self.config.routine = ''
             self.log_error(message, restart_counter_param=3 if self.log.get_testcase_stack() == 'setUpClass' else 0)
         item_list_data = self._get_item_list_data(po_item_list)
-        return item_list_data.get('value').upper()
+        return item_list_data.get('value').split('-')[0].strip().upper()
     
     def set_log_info_config(self):
         """
@@ -5315,7 +5315,7 @@ class PouiInternal(Base):
         return len(list(soup.select(term)))
 
 
-    def Program(self, program_name: str = "", program_desc: str = ""):
+    def Program(self, program_name: str = "", program_desc: str = "", module: str = ""):
         """
         [Internal]
 
@@ -5332,6 +5332,7 @@ class PouiInternal(Base):
 
         self.config.routine_type = 'Program'
         self.config.routine = program_name
+        self.config.routine_module = module
 
         if self.config.log_info_config:
             self.set_log_info_config()
@@ -5343,9 +5344,9 @@ class PouiInternal(Base):
         if not self.log.program:
             self.log.program = program_name
 
-        self.set_program(program_name, program_desc)
+        self.set_program(program_name, program_desc, module)
 
-    def set_program(self, program_name: str = "", program_desc: str = ""):
+    def set_program(self, program_name: str = "", program_desc: str = "", module: str = ""):
 
         logger().info(f"Setting program on the New Home: {program_name or program_desc}")
 
@@ -5353,6 +5354,7 @@ class PouiInternal(Base):
         search_term = "[class*='card-wrapper']"
         confirm_term = f"wa-button[caption='{self.language.confirm}']"
         attempts = 1
+        program_with_module = f'{program_name} - {module}' if module else None
 
         self.escape_to_main_menu()
 
@@ -5379,7 +5381,8 @@ class PouiInternal(Base):
             self._po_loading()
             if not program_name and program_desc:
                 self.config.routine = self._get_program_by_desc(program_desc)
-            self.click_po_list_box(value=program_desc, second_value=program_name, program_call=True, match_case=False)
+            self.click_po_list_box(value=program_desc, second_value=program_with_module or program_name, 
+                                   program_call=True, match_case=False)
 
             # -- Trecho de código temporário --
             self.wait_element_timeout(term=confirm_term, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container='body')
@@ -5524,14 +5527,19 @@ class PouiInternal(Base):
         self.close_coin_screen()
 
 
-    def SetLateralMenu(self, menu_itens: str, save_input: bool = True, click_menu_functional: bool = False) -> None:
-
-        logger().warning(f"\nSetLateralMenu is deprecated in the new Home; use Program instead. " +
-                        "The routine is defined using the text after the last '>' in the menu_items argument. " +
-                        "If multiple routines share the same description, the first is selected.\n")
+    def SetLateralMenu(self, menu_itens: str, program_name:str = '', module: str = '') -> None:        
         
-        program_desc = menu_itens.split('>')[-1].strip()
-        self.Program(program_desc=program_desc)
+        if not program_name:
+            logger().warning(
+                "\nSetLateralMenu in the New Home should receive 'program_name' and 'module' parameters. "
+                "When these parameters are not provided, the routine is defined using the text after the last '>' in the 'menu_items' parameter. "
+                "If multiple routines share the same description, the first is selected.\n"
+            )
+            
+            program_desc = menu_itens.split('>')[-1].strip()
+            self.Program(program_desc=program_desc)
+        else:
+            self.Program(program_name=program_name, module=module)
 
 
     def _click_dropdown(self, label, subitems, position):

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -4736,7 +4736,7 @@ class PouiInternal(Base):
             self.log_error(f"CheckBox '{label}' doesn't found!")
 
 
-    def click_combo(self, field, value='', position=1, second_value=''):
+    def click_combo(self, field, value='', position=1, second_value='', match_case=True):
         '''Select a value for list combo inputs.
 
         :param field: label of field
@@ -4747,6 +4747,8 @@ class PouiInternal(Base):
         :type : int
         :param second_value: value below the principal value (after the ":")
         :type : str
+        :param match_case: If True, requires exact normalized match; if False, allows partial normalized match.
+        :type : bool
         :return:
         '''
 
@@ -4773,19 +4775,21 @@ class PouiInternal(Base):
                     main_value = self.get_web_value(self.soup_to_selenium(po_input, twebview=True))
                     self.open_input_combo(po_combo_filtred)
                     self.send_keys(po_input_sel, value if value else second_value)
-                    self.click_po_list_box(value, second_value)
+                    self.click_po_list_box(value, second_value, match_case=match_case)
                     current_value = self.get_web_value(self.soup_to_selenium(po_input, twebview=True))
                     success = current_value.strip().lower() == main_value.strip().lower() if value else True
 
         if not success:
             self.log_error(f'Click on {value} of {field} Fail. Please Check')
 
-    def click_po_list_box(self, value="", second_value="", program_call=False) -> None:
+    def click_po_list_box(self, value="", second_value="", program_call=False, match_case=True) -> None:
         '''
         :param value: Value to select on po-list-box
         :type str
         :param second_value: value below the principal value (after the ":")
         :type : str
+        :param match_case: If True, requires exact normalized match; if False, allows partial normalized match.
+        :type : bool
         :return:
         '''
         orig_value = value
@@ -4793,7 +4797,7 @@ class PouiInternal(Base):
         value = value.strip().lower()
         second_value = second_value.strip().lower()
 
-        po_item_list = self._get_po_item_list(value, second_value)
+        po_item_list = self._get_po_item_list(value, second_value, match_case=match_case)
 
         if not po_item_list:
             message = f"Item list '{orig_value or orig_second_value}' not found"
@@ -4807,7 +4811,7 @@ class PouiInternal(Base):
         self.click(self.soup_to_selenium(po_item_list_div, twebview=True))
             
 
-    def _get_po_item_list(self, value="", second_value="") -> Tag:
+    def _get_po_item_list(self, value="", second_value="", match_case=True) -> Tag:
         """
         [Internal]
         
@@ -4817,18 +4821,20 @@ class PouiInternal(Base):
         :type value: str
         :param second_value: Secondary value to search for (value field). - **Default:** ""
         :type second_value: str
+        :param match_case: If True, requires exact normalized match; if False, allows partial normalized match. - **Default:** True
+        :type match_case: bool
         :return: The BeautifulSoup Tag object of the matching list item, or None if not found
         :rtype: Tag or None
         """
         try:
             self.wait_element(term='po-listbox')
             po_items_list = self.web_scrap(term='po-item-list', scrap_type=enum.ScrapType.CSS_SELECTOR, main_container='body')
-            return next(iter(list(filter(lambda x: self.find_po_item_list(x, value, second_value), po_items_list))), None)
+            return next(iter(list(filter(lambda x: self.find_po_item_list(x, value, second_value, match_case=match_case), po_items_list))), None)
         
         except Exception as e:
             return None
     
-    def find_po_item_list(self, po_item_list, param_label, param_value):
+    def find_po_item_list(self, po_item_list, param_label, param_value, match_case=True):
         '''This method is used to filter the po-item-list elements based on the label and value match.
 
 
@@ -4845,14 +4851,16 @@ class PouiInternal(Base):
         elem_label = item_list_data.get('label')
         elem_value = item_list_data.get('value')
 
+        compare = lambda expected, current: expected == current if match_case else expected in current
+
         if param_label and param_value:
-            return param_label == elem_label and param_value == elem_value
+            return compare(param_label, elem_label) and compare(param_value, elem_value)
 
         elif param_label and not param_value:
-            return param_label == elem_label
+            return compare(param_label, elem_label)
 
         elif not param_label and param_value:
-            return param_value == elem_value
+            return compare(param_value, elem_value)
 
     def _get_item_list_data(self, po_item_list) -> dict:
         """
@@ -5343,6 +5351,7 @@ class PouiInternal(Base):
 
         success = False
         search_term = "[class*='card-wrapper']"
+        confirm_term = f"wa-button[caption='{self.language.confirm}']"
         attempts = 1
 
         self.escape_to_main_menu()
@@ -5370,11 +5379,11 @@ class PouiInternal(Base):
             self._po_loading()
             if not program_name and program_desc:
                 self.config.routine = self._get_program_by_desc(program_desc)
-            self.click_po_list_box(value=program_desc, second_value=program_name, program_call=True)
+            self.click_po_list_box(value=program_desc, second_value=program_name, program_call=True, match_case=False)
 
             # -- Trecho de código temporário --
-            time.sleep(1)
-            btn_confirmar = lambda: self.get_current_DOM().select("wa-button[caption='Confirmar']")
+            self.wait_element_timeout(term=confirm_term, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container='body')
+            btn_confirmar = lambda: self.get_current_DOM().select(confirm_term)
             if btn_confirmar():
                 btn_confirmar_sel = lambda: self.soup_to_selenium(next(iter(btn_confirmar())))
                 self.click(btn_confirmar_sel())

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -9021,7 +9021,7 @@ class WebappInternal(Base):
                 self.SetLateralMenu(self.config.routine, save_input=False)
             else:
                 from tir.technologies.core.events import emit
-                emit('route.program', self.config.routine)
+                emit('route.program', self.config.routine, self.config.routine_module)
 
         self.tmenu_screen = None
 
@@ -9122,7 +9122,7 @@ class WebappInternal(Base):
                     self.SetLateralMenu(self.config.routine, save_input=False)
                 else:
                     from tir.technologies.core.events import emit
-                    emit('route.program', self.config.routine)
+                    emit('route.program', self.config.routine, self.config.routine_module)
         else:
             stack = next(iter(list(map(lambda x: x.function, filter(lambda x: re.search('tearDownClass', x.function), inspect.stack())))), None)
             if(stack and not stack.lower()  == "teardownclass"):
@@ -11905,7 +11905,7 @@ class WebappInternal(Base):
                     self.SetLateralMenu(self.config.routine, save_input=False)
                 else:
                     from tir.technologies.core.events import emit
-                    emit('route.program', self.config.routine)
+                    emit('route.program', self.config.routine, self.config.routine_module)
         else:
             stack = next(iter(list(map(lambda x: x.function, filter(lambda x: re.search('tearDownClass', x.function), inspect.stack())))), None)
             if(stack and not stack.lower()  == "teardownclass"):


### PR DESCRIPTION
# PR: Suporte a `module` para diferenciar rotina

## Resumo
Inclui o parâmetro `module` no fluxo de seleção de rotina (principalmente no New Home/POUI), permitindo escolher corretamente a rotina quando há opções com mesmo nome/descrição.

## Principais alterações
- Adição de `module` em métodos de `Program` e no fluxo de `SetLateralMenu`.
- Ajustes no `Router` e nos eventos (`route.program`) para propagar o módulo.
- Inclusão de `routine_module` na configuração para manter o contexto.
- Atualização das docstrings dos métodos alterados.

## Arquivos impactados
- `tir/main.py`
- `tir/technologies/core/config.py`
- `tir/technologies/core/router.py`
- `tir/technologies/poui_internal.py`
- `tir/technologies/webapp_internal.py`

## Pontos de atenção
- `Router.Program` mudou o segundo parâmetro para `module`; validar usos externos com argumento posicional.
- Em busca parcial (`match_case=False`), pode haver ambiguidade em itens muito parecidos.