### PR TITLE
Improve `SetFocus` active element check before click

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -6545,7 +6545,9 @@ class WebappInternal(Base):
                     self.scroll_to_element(element)
             try:
                 self.set_element_focus(element)
-                if self.switch_to_active_element() != element:
+                active_element = self.switch_to_active_element()
+                input_active_element = next(iter(self.execute_js_selector('input', self.switch_to_active_element())), None)
+                if active_element != element and input_active_element != element:
                     self.click(element, click_type=enum.ClickType.SELENIUM)
             except Exception as e:
                 logger().exception(f"Warning: SetFocus: '{field}' - Exception {str(e)}")


### PR DESCRIPTION
## Resumo
Este PR melhora a validação de foco no método `SetFocus` da classe `WebappInternal` para evitar cliques desnecessários quando o elemento alvo já está efetivamente ativo.

## O que mudou
- Foi incluída a captura do elemento ativo atual (`active_element`).
- Foi adicionada uma verificação extra para identificar se um `input` interno do elemento ativo corresponde ao elemento alvo.
- O clique de fallback agora ocorre apenas quando **nem** o elemento ativo **nem** seu `input` interno são o elemento esperado.

## Benefício esperado
- Mais robustez no fluxo de foco.
- Menor chance de interações redundantes em tela.