### PR TITLE
Add error logging for missing user and exit buttons in PouiInternal

### DIFF
--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -1761,13 +1761,17 @@ class PouiInternal(Base):
         while((time.time() < endtime) and not user_icon):
             soup = get_soup()
             user_icon = next(iter(soup.select('li.po-header-nav-customer-container')), None)
+        if not user_icon:
+            self.log_error("Couldn't find element user_icon")
         self.click(self.soup_to_selenium(user_icon), click_type=enum.ClickType(2))
         time.sleep(0.5)
 
         logger().debug('Clicking on exit button.')
         while((time.time() < endtime) and not exit_button):
             soup = get_soup()
-            exit_button = next(iter(soup.select('po-item-list[data-item-list*="Sair"] span')), None)
+            exit_button = next(iter(soup.select(f'po-item-list[data-item-list*="{self.language.exit}"] span')), None)
+        if not exit_button:
+            self.log_error("Couldn't find element exit_button")
         self.click(self.soup_to_selenium(exit_button), click_type=enum.ClickType(2))
         time.sleep(0.5)
 
@@ -1775,6 +1779,13 @@ class PouiInternal(Base):
         while((time.time() < endtime) and not finish_button):
             soup = get_soup()
             finish_button = next(iter(soup.select(f"po-button[p-label='{self.language.finish}']")), None)
+
+            if not finish_button:
+                buttons = soup.select(f"po-button")
+                finish_button = next(iter(list(filter(lambda x: x.text == self.language.finish, buttons))), None)
+        
+        if not finish_button:
+            self.log_error("Couldn't find element finish_button")
         self.click(self.soup_to_selenium(finish_button), click_type=enum.ClickType(2))
         time.sleep(0.5)
 


### PR DESCRIPTION
# PR: Melhorias de robustez no logout do POUI Internal

## Contexto
Este PR realiza ajustes no fluxo de logout em `PouiInternal` para reduzir falhas silenciosas na busca de elementos da interface.

## O que foi alterado
- Adicionado log de erro quando o ícone de usuário (`user_icon`) não é encontrado.
- Ajustado o seletor do botão de sair para usar `self.language.exit` (suporte a idioma), substituindo valor fixo (`"Sair"`).
- Adicionado log de erro quando o botão de sair (`exit_button`) não é encontrado.
- Incluído fallback para localizar o botão de finalizar (`finish_button`) por texto visível quando o seletor principal falha.
- Adicionado log de erro quando o botão de finalizar não é encontrado.


## Benefícios
- Melhor diagnósticos em cenário de falha no logout.
- Maior compatibilidade com ambientes multilíngues.
- Maior resiliência na identificação do botão de finalização.
- Trata timeout

## Impacto esperado
- Sem mudanças de contrato público.
- Comportamento funcional mantido, com observabilidade maior em falhas.
