### PR TITLE
Refactor item selection to enhance match_mode logic

### DIFF
--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -4771,33 +4771,34 @@ class PouiInternal(Base):
                 po_input = po_combo_filtred.find_next('input')
                 if po_input:
                     po_input_sel = self.soup_to_selenium(po_input, twebview=True)
+                    match_mode = 1 if match_case else 2
 
                     main_value = self.get_web_value(self.soup_to_selenium(po_input, twebview=True))
                     self.open_input_combo(po_combo_filtred)
                     self.send_keys(po_input_sel, value if value else second_value)
-                    self.click_po_list_box(value, second_value, match_case=match_case)
+                    self.click_po_list_box(value, second_value, match_mode=match_mode)
                     current_value = self.get_web_value(self.soup_to_selenium(po_input, twebview=True))
                     success = current_value.strip().lower() == main_value.strip().lower() if value else True
 
         if not success:
             self.log_error(f'Click on {value} of {field} Fail. Please Check')
 
-    def click_po_list_box(self, value="", second_value="", program_call=False, match_case=True) -> None:
+    def click_po_list_box(self, value="", second_value="", program_call=False, match_mode=1) -> None:
         '''
         :param value: Value to select on po-list-box
         :type str
         :param second_value: value below the principal value (after the ":")
         :type : str
-        :param match_case: If True, requires exact normalized match; if False, allows partial normalized match.
-        :type : bool
+        :param match_mode: Matching strategy used to find the item. 1 = exact match, 2 = contains, 3 = program code match.
+        :type : int
         :return:
         '''
         orig_value = value
         orig_second_value = second_value
-        value = value.strip().lower()
-        second_value = second_value.strip().lower()
+        value = str(value or '').strip().lower()
+        second_value = str(second_value or '').strip().lower()
 
-        po_item_list = self._get_po_item_list(value, second_value, match_case=match_case)
+        po_item_list = self._get_po_item_list(value, second_value, match_mode=match_mode)
 
         if not po_item_list:
             message = f"Item list '{orig_value or orig_second_value}' not found"
@@ -4811,7 +4812,7 @@ class PouiInternal(Base):
         self.click(self.soup_to_selenium(po_item_list_div, twebview=True))
             
 
-    def _get_po_item_list(self, value="", second_value="", match_case=True) -> Tag:
+    def _get_po_item_list(self, value="", second_value="", match_mode=1) -> Tag:
         """
         [Internal]
         
@@ -4821,20 +4822,40 @@ class PouiInternal(Base):
         :type value: str
         :param second_value: Secondary value to search for (value field). - **Default:** ""
         :type second_value: str
-        :param match_case: If True, requires exact normalized match; if False, allows partial normalized match. - **Default:** True
-        :type match_case: bool
+        :param match_mode: Matching strategy used to find the item. 1 = exact match, 2 = contains, 3 = program code match. - **Default:** 1
+        :type match_mode: int
         :return: The BeautifulSoup Tag object of the matching list item, or None if not found
         :rtype: Tag or None
         """
         try:
             self.wait_element(term='po-listbox')
             po_items_list = self.web_scrap(term='po-item-list', scrap_type=enum.ScrapType.CSS_SELECTOR, main_container='body')
-            return next(iter(list(filter(lambda x: self.find_po_item_list(x, value, second_value, match_case=match_case), po_items_list))), None)
+            return next(iter(list(filter(lambda x: self.find_po_item_list(x, value, second_value, match_mode=match_mode), po_items_list))), None)
         
         except Exception as e:
             return None
+
+    def _match_po_item_value(self, expected, current, match_mode=1):
+        """
+        [Internal]
+
+        Compare expected and current PO item values using the chosen match mode.
+        """
+        expected = str(expected or '').strip().lower()
+        current = str(current or '').strip().lower()
+        match_mode = match_mode if match_mode in [1, 2, 3] else 1
+
+        if match_mode == 2:
+            return expected in current
+
+        if match_mode == 3:
+            expected_program = expected.split('-', 1)[0].strip()
+            current_program = current.split('-', 1)[0].strip()
+            return expected_program == current_program
+
+        return expected == current
     
-    def find_po_item_list(self, po_item_list, param_label, param_value, match_case=True):
+    def find_po_item_list(self, po_item_list, param_label, param_value, match_mode=1):
         '''This method is used to filter the po-item-list elements based on the label and value match.
 
 
@@ -4851,16 +4872,17 @@ class PouiInternal(Base):
         elem_label = item_list_data.get('label')
         elem_value = item_list_data.get('value')
 
-        compare = lambda expected, current: expected == current if match_case else expected in current
+        compare_label = lambda expected, current: self._match_po_item_value(expected, current, 1 if match_mode == 3 else match_mode)
+        compare_value = lambda expected, current: self._match_po_item_value(expected, current, match_mode)
 
         if param_label and param_value:
-            return compare(param_label, elem_label) and compare(param_value, elem_value)
+            return compare_label(param_label, elem_label) and compare_value(param_value, elem_value)
 
         elif param_label and not param_value:
-            return compare(param_label, elem_label)
+            return compare_label(param_label, elem_label)
 
         elif not param_label and param_value:
-            return compare(param_value, elem_value)
+            return compare_value(param_value, elem_value)
 
     def _get_item_list_data(self, po_item_list) -> dict:
         """
@@ -5359,6 +5381,7 @@ class PouiInternal(Base):
         search_term = "[class*='card-wrapper']"
         confirm_term = f"wa-button[caption='{self.language.confirm}']"
         attempts = 1
+        match_mode = 1 if module else 3
         program_with_module = f'{program_name} - {module}' if program_name and module else None
 
         self.escape_to_main_menu()
@@ -5387,7 +5410,7 @@ class PouiInternal(Base):
             if not program_name and program_desc:
                 self.config.routine = self._get_program_by_desc(program_desc)
             self.click_po_list_box(value=program_desc, second_value=program_with_module or program_name, 
-                                   program_call=True, match_case=False)
+                                   program_call=True, match_mode=match_mode)
 
             # -- Trecho de código temporário --
             self.wait_element_timeout(term=confirm_term, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container='body')

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5381,7 +5381,7 @@ class PouiInternal(Base):
         search_term = "[class*='card-wrapper']"
         confirm_term = f"wa-button[caption='{self.language.confirm}']"
         attempts = 1
-        match_mode = 1 if module else 3
+        match_mode = 1 if module or program_desc else 3
         program_with_module = f'{program_name} - {module}' if program_name and module else None
 
         self.escape_to_main_menu()


### PR DESCRIPTION
## Resumo
Este PR ajusta a seleção de itens no POUI com a refatoração da estratégia de matching, substituindo `match_case` (bool) por `match_mode` (int), com modos explícitos de comparação.

## Contexto
O fluxo de abertura de rotina começa no `Router` e pode chegar ao `PouiInternal` por diferentes caminhos:

- `Program(program_name=..., module=...)`
- `Program(program_name=...)`
- `Program(program_desc=...)` (ex.: fallback do `SetLateralMenu` quando não há `program_name`)

Antes dos ajustes:

- A seleção do item em `po-item-list` podia considerar correspondência por **contém** no valor exibido.
- Em cenários com códigos parecidos, isso gerava falso positivo.
- Exemplo reportado: ao buscar `LOJA302`, o componente também podia casar com `LOJA3021`.

## Problema
O matching de seleção em `po-item-list` podia considerar correspondência por **contém**, causando falso positivo em cenários com códigos parecidos.

## Alterações realizadas

### Refatoração `match_case` -> `match_mode`
- Arquivo principal: `tir/technologies/poui_internal.py`
- Alterações:
  - Substituição de `match_case` por `match_mode` nos métodos internos de seleção (`click_po_list_box`, `_get_po_item_list`, `find_po_item_list`).
  - Inclusão de helper dedicado de comparação (`_match_po_item_value`) com modos explícitos:
    - `1`: exato
    - `2`: contains
    - `3`: comparação por código de rotina (parte antes de `-`)
  - Adaptação de `click_combo` para manter compatibilidade pública com `match_case`, convertendo internamente para `match_mode`.
  - Ajuste de `set_program` para usar `match_mode` no clique de `po-item-list`.

## Comportamento após ajuste
### 1) `program_name` + `module`
- Continua em `match_mode = 1` (comparação exata).

### 2) Somente `program_name`
- Continua em `match_mode = 3` (comparação por código da rotina).

### 3) Somente `program_desc`
- Mantém comparação exata por descrição, conforme comportamento esperado.

## Impacto esperado
- Torna a regra de matching mais clara e extensível com `match_mode`.
- Reduz risco de seleção incorreta em listas com itens semanticamente parecidos (ex.: códigos semelhantes).

## Risco e compatibilidade
- **Baixo risco**: alteração pontual na regra de decisão de modo de comparação.
- Mantém intactos os fluxos já esperados para:
  - comparação exata por módulo;
  - comparação por código quando só há `program_name`.
  - compatibilidade de API em `click_combo` com `match_case`.
