### PR TITLE
Add 'po-tag' to optional_term in WebappInternal class

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -5326,7 +5326,7 @@ class WebappInternal(Base):
         if not timeout:
             timeout = 1200
 
-        optional_term = ".tsay, .tgroupbox, wa-text-view, .po-page-header-title"
+        optional_term = ".tsay, .tgroupbox, wa-text-view, .po-page-header-title, po-tag"
         main_container = self.containers_selectors["AllContainers"]
         twebview = False
 


### PR DESCRIPTION
## Resumo
Ajuste no `WaitShow` para atender um caso identificado na rotina `ATFA175`.

## Contexto
Na tela inicial da rotina, a validação considerava o texto "Ativo Fixo" na home antiga. Com a nova home, esse texto passou a ser renderizado dentro da tag `po-tag`, o que fazia o `WaitShow` não reconhecer corretamente o elemento esperado.

## Alteração realizada
Foi incluído `po-tag` na lista de seletores aceitos em `optional_term` na classe `WebappInternal`, permitindo que o `WaitShow` também localize esse conteúdo no novo layout.

## Impacto
Corrige o comportamento da rotina `ATFA175` na nova home, mantendo compatibilidade com os elementos já tratados anteriormente.
