### PR TITLE
hotfix: remove filters improve

### DIFF
--- a/tir/technologies/core/language.py
+++ b/tir/technologies/core/language.py
@@ -94,6 +94,7 @@ class LanguagePack:
         self.filters = languagepack["Filters"]
         self.apply_filters = languagepack["Apply Filters"]
         self.remove_filters = languagepack["Remove Filters"]
+        self.remove_all_filters = languagepack["Remove All Filters"]
         self.old_browse_edit = languagepack["Old Browse Edit"]
         self.old_browse_delete = languagepack["Old Browse Delete"]
         self.old_browse_insert = languagepack["Old Browse Insert"]
@@ -206,6 +207,7 @@ class LanguagePack:
             "Filters": "Filters",
             "Apply Filters": "Apply filters",
             "Remove Filters": "Remove filters",
+            "Remove All Filters": "Remove all",
 
             "Old Browse Edit":"Edit",
             "Old Browse Delete":"Delete",
@@ -315,6 +317,7 @@ class LanguagePack:
             "Filters": "Filtros",
             "Apply Filters": "Aplicar Filtros",
             "Remove Filters": "Remover filtros",
+            "Remove All Filters": "Remover todos",
 
             "Old Browse Edit":"Alterar",
             "Old Browse Delete":"Excluir",
@@ -423,6 +426,7 @@ class LanguagePack:
             "Filters": "Filtros",
             "Apply Filters": "Aplicar Filtros",
             "Remove Filters": "Eliminar filtros",
+            "Remove All Filters": "Eliminar todos",
             "Old Browse Edit":"Modificar",
             "Old Browse Delete":"Borrar",
             "Old Browse Insert":"Incluir",
@@ -532,6 +536,7 @@ class LanguagePack:
             "Filters": "Фильтры",
             "Apply Filters": "Применить фильтры",
             "Remove Filters": "Удалить фильтры",
+            "Remove All Filters": "Удалить все",
 
             "Old Browse Edit":"Редактировать",
             "Old Browse Delete":"Удалить",

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5748,15 +5748,44 @@ class PouiInternal(Base):
         >>> self._remove_filters_from_browse()
         """
 
-        po_tag_filter = self._get_po_tag(text=self.language.remove_filters, container_selector='kendo-grid')
-        if po_tag_filter:
-            logger().debug("Found applied filters, clicking to remove filters.")
-            clickable = po_tag_filter.select_one('.po-tag-wrapper.po-clickable')
-            target = clickable if clickable else po_tag_filter
+        soup = self.get_current_DOM(twebview=True)
+        kendo_grid = soup.select_one('kendo-grid')
+        if not kendo_grid:
+            logger().debug("No kendo-grid found; skipping filter removal.")
+            return
+
+        # Scenario 1: "Remove filters" or "Remove all" tag (multiple filters applied)
+        remove_tag = self._get_po_tag(text=self.language.remove_filters, container_selector='kendo-grid') or \
+                     self._get_po_tag(text=self.language.remove_all_filters, container_selector='kendo-grid')
+
+        if remove_tag:
+            logger().debug("Found 'Remove all filters' tag, clicking.")
+            clickable = remove_tag.select_one('.po-tag-wrapper.po-clickable')
+            target = clickable if clickable else remove_tag
             self.poui_click(target)
             self._po_loading()
+            return
+
+        # Scenario 2: individual tags with "x" icon (single filter applied)
+        # Refresh DOM to capture the updated state after any previous click
+        soup = self.get_current_DOM(twebview=True)
+        kendo_grid = soup.select_one('kendo-grid')
+        if not kendo_grid:
+            logger().debug("No kendo-grid found after DOM refresh; skipping filter removal.")
+            return
+
+        individual_tags = [
+            tag for tag in kendo_grid.select('po-tag')
+            if tag.select_one('.po-tag-remove')
+        ]
+        if individual_tags:
+            logger().debug(f"Found {len(individual_tags)} individual filter tag(s), removing each.")
+            for tag in individual_tags:
+                clickable = tag.select_one('.po-tag-remove')
+                self.poui_click(clickable)
+                self._po_loading()
         else:
-            logger().debug("No 'Remove Filters' found; skipping filter removal.")
+            logger().debug("No active filter tags found; skipping filter removal.")
 
 
     def _get_po_tag(self, text: str, container_selector: str):


### PR DESCRIPTION
## Descrição

Melhoria na lógica de remoção de filtros aplicados no componente `kendo-grid` (PO UI), cobrindo cenários que antes não eram tratados corretamente.

---

## Arquivos Alterados

### `tir/technologies/core/language.py`
- Adicionada nova chave `remove_all_filters` ao `LanguagePack`.
- Tradução incluída em todos os idiomas suportados:
  - **Inglês:** `"Remove all"`
  - **Português (BR):** `"Remover todos"`
  - **Espanhol:** `"Eliminar todos"`
  - **Russo:** `"Удалить все"`

### `tir/technologies/poui_internal.py` — método `_remove_filters_from_browse`
Refatoração completa do método para suportar dois cenários distintos de remoção de filtros:

| Cenário | Situação | Ação |
|---------|----------|------|
| **1** | Tag "Remove filters" ou "Remove all" presente (múltiplos filtros aplicados) | Clica na tag para remover todos de uma vez |
| **2** | Tags individuais com ícone "x" (filtro único aplicado) | Itera e clica em cada tag individualmente |

**Melhorias adicionais:**
- Verificação de existência do `kendo-grid` no DOM antes de qualquer ação (evita erros silenciosos).
- Re-consulta ao DOM após o cenário 1 para capturar estado atualizado.
- Logs de debug mais informativos em todos os fluxos.

---

## Motivação

O comportamento anterior falhava ao tentar remover filtros quando apenas um filtro estava aplicado, pois a tag exibida neste caso não continha o texto "Remove filters", e sim um ícone de remoção individual (`po-tag-remove`). Este hotfix garante que ambos os cenários sejam cobertos corretamente.

---

## Tipo de Mudança
- [x] Bug fix / Hotfix
- [x] Melhoria de comportamento existente