### PR TITLE
Hotfix POUI Program without looping

### DIFF
--- a/tir/technologies/core/utils.py
+++ b/tir/technologies/core/utils.py
@@ -1,6 +1,11 @@
 from typing import Iterable, Optional, Set
 import inspect
 import os
+import time
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.keys import Keys
+from tir.technologies.core.logging_config import logger
+from tir.technologies.core import enum
 
 class Utils:
     """Shared utility methods for TIR technologies."""
@@ -72,3 +77,66 @@ class Utils:
                 return stack_item.function
 
         return fallback
+
+    def check_tmenu_screen(self, caller) -> bool:
+        """[Internal]
+        
+        Checks if the main menu screen (tmenu) is currently displayed.
+        
+        Args:
+            caller: The technology instance with config, web_scrap, and element_is_displayed methods.
+        
+        Returns:
+            bool: True if menu screen is displayed, False otherwise.
+        """
+        
+        
+        try:
+            twebview = True if caller.config.new_home else False
+            return caller.element_is_displayed(
+                next(iter(caller.web_scrap(term=".tmenu, .dict-tmenu, [class*='card-wrapper']", scrap_type=enum.ScrapType.CSS_SELECTOR, main_container="body", twebview=twebview)),
+                     None))
+        except:
+            return False
+
+    def escape_to_main_menu(
+        self,
+        caller,
+        container_term: Optional[str] = None
+    ) -> None:
+        """Navigate back to the main menu by sending ESC keys and closing open dialogs.
+
+        Waits until the main menu screen is visible and, when `container_term` is provided,
+        verifies that only one dialog layer remains before declaring success.
+
+        Args:
+            caller: The technology instance (WebappInternal or PouiInternal) that owns
+                    the driver, config, and helper methods.
+            container_term: CSS selector used to count dialog layers and confirm only
+                            one remains before declaring success.
+                        Default: None (no layer check). Webapp should pass
+                        "wa-dialog".
+        """
+        
+        success = False
+
+        endtime = time.time() + caller.config.time_out / 2
+        while time.time() < endtime and not success:
+            logger().info('Escape to menu')
+            ActionChains(caller.driver).send_keys(Keys.ESCAPE).perform()
+
+            if any([caller.check_warning_screen(), caller.check_coin_screen(), caller.check_news_screen()]) \
+                    and (not container_term or caller.check_layers(container_term) > 1):
+                logger().info('Found layers after Escape to menu')
+                caller.close_screen_before_menu()
+
+            menu_screen = self.check_tmenu_screen(caller)
+            container_layers = (caller.check_layers(container_term) == 1) if container_term else True
+            success = menu_screen and container_layers
+
+            logger().debug(f'Check Menu Screen: {menu_screen}')
+            if container_term:
+                logger().debug(f'{container_term} layers: {container_layers}')
+
+        if not success:
+            caller.log_error('Home screen not found!')

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5450,7 +5450,7 @@ class PouiInternal(Base):
         self.close_after_routine(program_name)
 
         if not success:
-            message = "Couldn't find Program field."
+            message = "Couldn't set the program."
             self.config.routine_type = ''
             self.config.routine = ''
             self.log_error()

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5386,71 +5386,66 @@ class PouiInternal(Base):
 
     def set_program(self, program_name: str = "", program_desc: str = "", module: str = ""):
 
+        self.escape_to_main_menu()
+
         logger().info(f"Setting program on the New Home: {program_name or program_desc}")
 
         success = False
         search_term = "[class*='card-wrapper']"
         confirm_term = f"wa-button[caption='{self.language.confirm}']"
-        attempts = 1
         match_mode = 1 if module or program_desc else 3
-        program_with_module = f'{program_name} - {module}' if program_name and module else None
-
-        self.escape_to_main_menu()
+        program_with_module = f'{program_name} - {module}' if program_name and module else None        
+        ele_hidden = None
+        wtb_after = None    
 
         self.wait_element(term=search_term, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container='body')
         
         get_wtb = lambda: len(self.get_current_DOM().select('wa-tab-button'))
         wtb_before = get_wtb()
 
-        endtime = time.time() + self.config.time_out
-        while time.time() < endtime and not success:
-            logger().debug(f'Attempt {attempts} to set the program. Tabs count before: {wtb_before}')
+        hide_element = next(iter(self.web_scrap(term=search_term, 
+                                                scrap_type=enum.ScrapType.CSS_SELECTOR, 
+                                                main_container='body')), None)
+        
+        self.InputValue(self.language.input_set_program, program_name or program_desc, 1, exec_enter_tab=False)
+        self._po_loading()
 
-            if attempts > 1:
-                time.sleep(0.5)
+        if not program_name and program_desc:
+            self.config.routine = self._get_program_by_desc(program_desc)
+        
+        logger().debug(f'Selecting the routine')
 
-            ele_hidden = None
-            wtb_after = None
+        self.click_po_list_box(value=program_desc, second_value=program_with_module or program_name, 
+                                program_call=True, match_mode=match_mode)
+        
+        # -- Trecho de código temporário --
+        btn_confirmar = lambda: self.get_current_DOM().select(confirm_term)
+        endtime = time.time() + 30
+        while time.time() < endtime:
+            logger().debug(f'Waiting for the confirm button.')
 
-            hide_element = next(iter(self.web_scrap(term=search_term, 
-                                                    scrap_type=enum.ScrapType.CSS_SELECTOR, 
-                                                    main_container='body')), None)
-            
-            self.InputValue(self.language.input_set_program, program_name or program_desc, 1, exec_enter_tab=False)
-            self._po_loading()
-            if not program_name and program_desc:
-                self.config.routine = self._get_program_by_desc(program_desc)
-            self.click_po_list_box(value=program_desc, second_value=program_with_module or program_name, 
-                                   program_call=True, match_mode=match_mode)
-
-            # -- Trecho de código temporário --
-            self.wait_element_timeout(term=confirm_term, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container='body')
-            btn_confirmar = lambda: self.get_current_DOM().select(confirm_term)
             if btn_confirmar():
                 btn_confirmar_sel = lambda: self.soup_to_selenium(next(iter(btn_confirmar())))
                 self.click(btn_confirmar_sel())
-            # -- --
+                logger().debug(f'Confirm button clicked.')
+                break
+            time.sleep(1)
+        # -- --
 
-            logger().debug(f'Waiting for the new home to disappear.')
-            self.wait_element_is_not_displayed(hide_element, timeout=60)
-            ele_hidden = not self.element_is_displayed(hide_element)
-            logger().debug(f'New home disappeared.')
+        self.wait_element_is_not_displayed(hide_element, timeout=60)
+        ele_hidden = not self.element_is_displayed(hide_element)
+        logger().debug(f'New home disappeared.')
 
-            endtime_routine = time.time() + (self.config.time_out / 2)
+        endtime = time.time() + self.config.time_out
+        while time.time() < endtime:
+            logger().debug(f'Waiting for a new tab to open.')
 
-            while time.time() < endtime_routine:
-                logger().debug(f'Waiting for a new tab to open.')
+            wtb_after = get_wtb()
+            if wtb_before != wtb_after:
+                break
+            time.sleep(1)
 
-                wtb_after = get_wtb()
-
-                if wtb_before != wtb_after:
-                    break
-
-                time.sleep(1)
-
-            success = (ele_hidden) and (wtb_before != wtb_after)
-
-            attempts += 1
+        success = (ele_hidden) and (wtb_before != wtb_after)
 
         self.close_after_routine(program_name)
 

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5420,7 +5420,7 @@ class PouiInternal(Base):
         
         # -- Trecho de código temporário --
         btn_confirmar = lambda: self.get_current_DOM().select(confirm_term)
-        endtime = time.time() + 30
+        endtime = time.time() + 120
         while time.time() < endtime:
             logger().debug(f'Waiting for the confirm button.')
 

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -1028,7 +1028,7 @@ class PouiInternal(Base):
 
         logger().info('Getting log info')
 
-        self.escape_to_main_menu("[class*='card-wrapper']")
+        self.utils.escape_to_main_menu(caller=self)
 
         logger().debug('Clicking on dots icon')
         self.switch_to_header_iframe()
@@ -5316,28 +5316,6 @@ class PouiInternal(Base):
         self.log_error('Please check config.json key "Release".It is necessary to generate the log on the dashboard. ex: "Release": "12.1.2310" ')
 
 
-    def escape_to_main_menu(self):
-        """
-
-        """
-        term = "[class*='card-wrapper']"
-
-        endtime = time.time() + self.config.time_out /2
-        while time.time() < endtime and not self.element_exists(term=term, scrap_type=enum.ScrapType.CSS_SELECTOR,
-                                                                main_container="body", check_error=False):
-
-            logger().info('Escape to menu')
-            ActionChains(self.driver).send_keys(Keys.ESCAPE).perform()
-
-            if any([self.check_warning_screen(), self.check_coin_screen(), self.check_news_screen()]):
-                logger().info('Found layers after Escape to menu')
-                self.close_screen_before_menu()
-
-            # wait trasitions between screens to avoid errors in layers number
-            self.wait_element_timeout(term=term, scrap_type=enum.ScrapType.CSS_SELECTOR,
-                                      timeout=6, main_container='body')
-
-
     def check_layers(self, term):
         """
         [Internal]
@@ -5395,7 +5373,7 @@ class PouiInternal(Base):
         match_mode = 1 if module or program_desc else 3
         program_with_module = f'{program_name} - {module}' if program_name and module else None
 
-        self.escape_to_main_menu()
+        self.utils.escape_to_main_menu(caller=self)
 
         self.wait_element(term=search_term, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container='body')
         
@@ -5548,7 +5526,7 @@ class PouiInternal(Base):
         if module:
             self.config.module = module
 
-        self.escape_to_main_menu()
+        self.utils.escape_to_main_menu(caller=self)
 
         element = self.change_environment_element_home_screen()
         if element:

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -1254,7 +1254,10 @@ class WebappInternal(Base):
         if module:
             self.config.module = module
 
-        self.escape_to_main_menu()
+        self.utils.escape_to_main_menu(
+            caller=self,
+            container_term="wa-dialog"
+        )
 
         element = self.change_environment_element_home_screen()
         if element:
@@ -1890,7 +1893,10 @@ class WebappInternal(Base):
         try:
             logger().info(f"Setting program: {program_name}")
 
-            self.escape_to_main_menu()
+            self.utils.escape_to_main_menu(
+                caller=self,
+                container_term="wa-dialog"
+            )
 
             self.wait_element(term=cget_term, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container="body")
 
@@ -1958,41 +1964,6 @@ class WebappInternal(Base):
             raise error
         except Exception as e:
             logger().exception(str(e))
-
-    def escape_to_main_menu(self):
-        """[Internal]
-
-        Tries to navigate back to the main menu screen by sending ESC keys and closing open dialogs.
-        Waits until the menu is visible and there is only one dialog layer.
-
-        :return: None
-        """
-        success = False
-        container_term = 'wa-dialog'
-
-        endtime = time.time() + self.config.time_out /2
-        while time.time() < endtime and not success:
-            logger().info('Escape to menu')
-            ActionChains(self.driver).send_keys(Keys.ESCAPE).perform()
-
-            if any([self.check_warning_screen(), self.check_coin_screen(), self.check_news_screen()]) \
-                and self.check_layers(container_term) > 1:
-                logger().info('Found layers after Escape to menu')
-                self.close_screen_before_menu()
-
-            menu_screen = self.check_tmenu_screen()
-            container_layers = self.check_layers(container_term) == 1
-            success = menu_screen and container_layers
-
-            logger().debug(f'Check Menu Screen: {menu_screen}')
-            logger().debug(f'wa-dialog layers: {container_layers}')
-
-        if not success:
-            self.log_error('Home screen not found!')     
-        
-        # wait trasitions between screens to avoid errors in layers number
-        self.wait_element_timeout(term=container_term, scrap_type=enum.ScrapType.CSS_SELECTOR,
-                                    position=2, timeout=6, main_container='body')
 
     def check_layers(self, term):
         """
@@ -4490,7 +4461,10 @@ class WebappInternal(Base):
         endtime = time.time() + self.config.time_out
         menu_itens = list(map(str.strip, menu_itens.split(">")))
 
-        self.escape_to_main_menu()
+        self.utils.escape_to_main_menu(
+            caller=self,
+            container_term="wa-dialog"
+        )
 
         self.wait_element(term=menu_term, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container="body")
 


### PR DESCRIPTION
## Objetivo
Evitar que o processo de abertura de rotina no `set_program` reinicie desde o começo quando ocorre falha em etapas finais do fluxo.

## O que foi alterado
- Removido o looping externo que reexecutava todo o fluxo de `set_program`.
- Mantido o fluxo principal de forma linear:
  - navegação até o menu principal,
  - preenchimento do input de programa,
  - seleção da rotina,
  - clique no confirmar (quando disponível),
  - validação de mudança de tela/aba.
- Ajustado o tempo de espera do botão de confirmação para **2 minutos** (`120s`).

## Motivação
No cenário anterior, quando havia erro no final do processo, o fluxo reiniciava do início e tentava preencher novamente o primeiro input, que já não estava mais disponível na tela, causando nova falha.

## Observações
- Não foi adicionado retry global do `set_program`, pois os métodos internos chamados já possuem tentativas/retries localizados.
- O botão de confirmação continua sendo clicado apenas quando identificado na tela, com espera de até 120s.
