### PR TITLE
hotfix: Add RemoveBrowseFilters method to Poui class

### DIFF
--- a/tir/main.py
+++ b/tir/main.py
@@ -618,6 +618,11 @@ class Webapp():
          - **Default:** []
         :type filters: list[dict[str, str]]
 
+        .. note::
+            When used with the **New Browse** (kendo-grid), this method automatically removes all
+            active filters before performing the search, ensuring the results are not affected by
+            previously applied filter conditions.
+
         Usage:
 
         >>> # To search using the first search box and default search key:
@@ -2358,3 +2363,14 @@ class Poui():
         """
         self.config._flag_is_new_browse = True
         self.__poui._set_browse_filters(filters)
+
+    def RemoveBrowseFilters(self):
+        """
+        Removes all active filters from the THF Browse (kendo-grid) component.
+
+        Usage:
+
+        >>> # Call the method:
+        >>> oHelper.RemoveBrowseFilters()
+        """
+        self.__poui._remove_filters_from_browse()


### PR DESCRIPTION
## Description

Adds the `RemoveBrowseFilters` method to the `Poui` class, allowing the removal of all active filters from the THF Browse (kendo-grid) component.

## Changes

### `tir/main.py`
- **New method `Poui.RemoveBrowseFilters`**: Removes all active filters from the THF Browse (kendo-grid) component by calling `_remove_filters_from_browse()` on the internal POUI instance.
- **Updated docstring for `Webapp.SearchBrowse`**: Added a note informing that when using the **New Browse** (kendo-grid), the method automatically removes all active filters before performing the search, ensuring results are not affected by previously applied filter conditions.

## Usage

```python
# Remove all active filters from the browse:
oHelper.RemoveBrowseFilters()
```

## Files Changed

| File | Changes |
|------|---------|
| `tir/main.py` | +16 lines — new method + docstring update |