### PR TITLE
fix: use get() method for safe dictionary access in WebappInternal class

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -2065,12 +2065,12 @@ class WebappInternal(Base):
                 self.click(icon_s)
 
             container_end = self.get_current_container()
-            if (container['id']  == container_end['id']):
+            if (container.get('id') == container_end.get('id')):
                 input_field = lambda: self.driver.find_element(By.XPATH, xpath_soup(element))
                 self.set_element_focus(input_field())
                 self.send_keys(input_field(), Keys.F3)
 
-            while( time.time() < endtime and container['id']  == container_end['id']):
+            while( time.time() < endtime and container.get('id') == container_end.get('id')):
                 container_end = self.get_current_container()
                 time.sleep(0.01)
 


### PR DESCRIPTION
## Descrição

Este hotfix corrige um potencial `KeyError` no método responsável por tratar a tecla **F3** na classe `WebappInternal`, substituindo o acesso direto a chaves de dicionário pelo método seguro `.get()`.

## Problema

O acesso direto `container['id']` e `container_end['id']` em `webapp_internal.py` causava `KeyError` quando a chave `'id'` não estava presente no dicionário retornado por `get_current_container()`, resultando em falha inesperada durante a execução.

## Solução

Substituição do acesso direto por `.get('id')`, que retorna `None` em vez de lançar exceção caso a chave não exista:

```python
# Antes
if (container['id'] == container_end['id']):
while( time.time() < endtime and container['id'] == container_end['id']):

# Depois
if (container.get('id') == container_end.get('id')):
while( time.time() < endtime and container.get('id') == container_end.get('id')):
```

## Arquivos Alterados

- `tir/technologies/webapp_internal.py` — 2 linhas modificadas

## Tipo de Mudança

- [x] Bug fix (correção que resolve um problema sem quebrar funcionalidades existentes)
