### PR TITLE
fix: normalize column names to improve missing column checks

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -5835,15 +5835,17 @@ class WebappInternal(Base):
             if df is None or df.empty:
                 reached_end = True
                 break
-
+            
+            columns_normalized = list(map(lambda x: str(x).strip().lower(), df.columns))
             missing_columns = []
             if first_column:
                 cols_to_check = first_column if isinstance(first_column, list) else [first_column]
+
                 for col in cols_to_check:
-                    if col not in df.columns:
+                    if str(col).strip().lower() not in columns_normalized:
                         missing_columns.append(col)
 
-            if second_column and second_column not in df.columns:
+            if second_column and str(second_column).strip().lower() not in columns_normalized:
                 missing_columns.append(second_column)
 
             if missing_columns:


### PR DESCRIPTION
### Problema
A validação de colunas no `click_box_dataframe` era case-sensitive. Isso gerava falso positivo de coluna faltante quando o parâmetro do `ClickBox` vinha com case diferente da coluna da grid.

Exemplo real:
- rotina: **RMIINTMANUALPDV**
- execução: **TIR_DEVELOP id 20260513**
- parâmetro informado: `"X"`
- coluna disponível na grid: `"x"`
- resultado anterior: falha de validação de colunas faltantes.

### Solução
Foi aplicada normalização (`strip().lower()`) nos nomes das colunas da grid e nos parâmetros de coluna (`first_column` e `second_column`) durante a checagem de colunas faltantes.

### Impacto esperado
- Corrige falsos positivos causados por diferença de case e espaços.
- Mantém comportamento para colunas realmente ausentes.
- Alteração localizada e de baixo risco.

### Observação
Em cenários raros com colunas distintas apenas por maiúsculas/minúsculas, a validação passa a tratá-las como equivalentes. 