### PR TITLE
Handle browse exit using X button

### DIFF
--- a/tir/main.py
+++ b/tir/main.py
@@ -57,6 +57,7 @@ class Webapp():
         subscribe('webapp.setup', self.__webapp.Setup)
         subscribe('webapp.log_error', self.__webapp.log_error)
         subscribe('webapp.set_button', self.__webapp.SetButton)
+        subscribe('webapp.set_button_x', self.__webapp.set_button_x)
 
         subscribe('webapp.close_warning_screen_after_routine', self.__webapp.close_warning_screen_after_routine)
         subscribe('webapp.close_coin_screen_after_routine', self.__webapp.close_coin_screen_after_routine)

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -946,7 +946,7 @@ class PouiInternal(Base):
             self.set_button_x()
 
     def set_button_x(self, position=1, check_error=True):
-        
+
         from tir.technologies.core.events import emit
         emit('webapp.set_button_x')
         return
@@ -3837,6 +3837,13 @@ class PouiInternal(Base):
 
 
         """
+
+        logger().info(f"Clicking on {button}")
+
+        if (button.lower().strip() == "x"):
+            self.set_button_x()
+            return
+        
         position -= 1
         element = None
         button_element = None
@@ -3844,8 +3851,7 @@ class PouiInternal(Base):
 
         if not self.config.poui:
             self.twebview_context = True
-
-        logger().info(f"Clicking on {button}")
+                
         self.wait_element(term=button, optional_term=selector, scrap_type=enum.ScrapType.MIXED)
         endtime = time.time() + self.config.time_out
         while (time.time() < endtime and not (element and button_element)):
@@ -6026,10 +6032,6 @@ class PouiInternal(Base):
 
         button_normalized = str(button).lower().strip() if button is not None else ""
         sub_item_normalized = str(sub_item).lower().strip() if sub_item is not None else ""
-
-        if (button_normalized == "x"):
-            self.set_button_x()
-            return
 
         # Map legacy button names to their POUI equivalents.
         button_dict = {

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -946,6 +946,11 @@ class PouiInternal(Base):
             self.set_button_x()
 
     def set_button_x(self, position=1, check_error=True):
+        
+        from tir.technologies.core.events import emit
+        emit('webapp.set_button_x')
+        return
+    
         position -= 1
         term_button = ".ui-button.ui-dialog-titlebar-close[title='Close'], img[src*='fwskin_delete_ico.png'], img[src*='fwskin_modal_close.png']"
         wait_button = self.wait_element(term=term_button, scrap_type=enum.ScrapType.CSS_SELECTOR, position=position, check_error=check_error)
@@ -6023,7 +6028,7 @@ class PouiInternal(Base):
         sub_item_normalized = str(sub_item).lower().strip() if sub_item is not None else ""
 
         if (button_normalized == "x"):
-            self.set_button_exit()
+            self.set_button_x()
             return
 
         # Map legacy button names to their POUI equivalents.


### PR DESCRIPTION
## 1. Contexto
Anteriormente, no novo browse, a saída da rotina era realizada pelo botão **"Sair"**. O comportamento esperado foi alterado para que a saída aconteça pelo botão **"X"**.

## 2. O que foi alterado
- Atualizado o fluxo de tratamento de botões para reconhecer **"X"** como ação de saída da rotina no novo browse.
- Adicionado desvio para a implementação específica do Webapp, pois o botão **"X"** atual pertence ao comportamento do Webapp.

## 3. Impacto no fluxo anterior
- **Antes:** a ação de saída no novo browse era vinculada ao botão **"Sair"**.
- **Agora:** a ação de saída está vinculada ao botão **"X"**.
- Esta é uma mudança funcional de fluxo e pode impactar testes que clicam explicitamente em **"Sair"** para sair da rotina.

## 4. Riscos e mitigação
### Riscos
- Regressão em cenários que ainda esperam **"Sair"** como ação principal de saída.
- Migração futura para POUI pode gerar lógica duplicada se o desvio não for removido.

### Mitigação
- Manter, por enquanto, o tratamento explícito de **"X"** centralizado no fluxo Webapp.
- Adicionar testes de regressão validando o comportamento de saída no novo browse.
- Caso o POUI adote o mesmo comportamento de fechamento, remover o evento de desvio e implementar diretamente no POUI para evitar acoplamento.

## 5. Como validar (passo a passo)
1. Executar um cenário que abra o novo browse.
2. Acionar a saída usando `SetButton("X", is_browse=True)`.
3. Confirmar que a rotina é encerrada com sucesso e que não há modal bloqueando a tela.
4. Validar que os fluxos com botões que não são "X" (`SetButton("Salvar")`, `SetButton("Confirmar")`, `SetButton("?")`) continuam funcionando.
5. Validar ao menos um cenário que antes usava **"Sair"**, ajustando a asserção para o novo comportamento esperado.

## 6. Pendências conhecidas
- Adicionar/ajustar testes automatizados para a transição de fluxo de **"Sair"** para **"X"**.
- Avaliar se esse comportamento deve ser implementado nativamente no POUI em uma alteração futura.
- Se a implementação no POUI for adotada, remover o desvio temporário de evento para o Webapp.
