### PR TITLE
Fix environment input handling for 'sigaadv' (release >= 2610)

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -1177,6 +1177,8 @@ class WebappInternal(Base):
                     environment_element = next(iter(environment_elements))
                     environment_element = environment_element.find_parent('pro-system-module-lookup')
                     environment_element = next(iter(environment_element.select('input')), None)
+                elif not environment_elements and self.config.initial_program.lower().strip() == 'sigaadv':
+                    enable = False
             else:
                 if self.webapp_shadowroot(shadow_root=shadow_root):
                     environment_elements = self.web_scrap(term="[name='cAmb']", scrap_type=enum.ScrapType.CSS_SELECTOR,

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -1156,6 +1156,10 @@ class WebappInternal(Base):
         Fills the module/environment field on the environment screen with the value configured in config.json.
         Retries until the value matches or the timeout is reached. Skips filling if the field is disabled.
 
+        When ``initial_program`` is ``sigaadv`` and the environment field is not present on the screen
+        (e.g. Protheus release >= 2610 with the new home screen), the loop exits immediately to avoid
+        running until timeout.
+
         :param shadow_root: Indicates whether to use shadow root selectors. - **Default:** None
         :type shadow_root: bool
         :param container: CSS selector of the container element. - **Default:** None
@@ -1177,7 +1181,8 @@ class WebappInternal(Base):
                     environment_element = next(iter(environment_elements))
                     environment_element = environment_element.find_parent('pro-system-module-lookup')
                     environment_element = next(iter(environment_element.select('input')), None)
-                elif not environment_elements and self.config.initial_program.lower().strip() == 'sigaadv':
+                elif not environment_elements and (self.config.initial_program or '').lower().strip() == 'sigaadv':
+                    logger().debug('Skipping environment fill: initial_program is sigaadv and no environment field found (release >= 2610).')
                     enable = False
             else:
                 if self.webapp_shadowroot(shadow_root=shadow_root):


### PR DESCRIPTION
## Contexto

A partir da release **2610** do Protheus, a nova home screen (POUI) não exibe mais o campo de ambiente (`cAmb`) no Setup quando o `initial_program` configurado é `SIGAADV`. Com o comportamento anterior, a função `filling_environment` ficava em loop até o timeout aguardando um campo que nunca seria renderizado, causando lentidão desnecessária na inicialização.

## O que foi alterado

**Arquivo:** `tir/technologies/webapp_internal.py`  
**Função:** `filling_environment`

- Adicionado `elif` dentro do bloco `poui_login` para encerrar o loop imediatamente quando o campo de ambiente não é encontrado e o `initial_program` é `sigaadv`.
- Aplicado guard contra `None` em `self.config.initial_program` usando `(self.config.initial_program or '')`.
- Adicionado `logger().debug(...)` para rastreabilidade quando o skip ocorre.
- Docstring atualizada para documentar o comportamento de skip para a release >= 2610.

## Impacto no fluxo anterior

| Cenário | Fluxo anterior | Fluxo novo |
|---|---|---|
| `poui_login=True` + `sigaadv` + sem campo (release ≥ 2610) | Loop até timeout | Encerra imediatamente ✅ |
| `poui_login=True` + `sigaadv` + **com** campo (release < 2610) | Preenche normalmente | Preenche normalmente ✅ |
| `poui_login=True` + outro programa inicial | Comportamento inalterado | Comportamento inalterado ✅ |
| `poui_login=False` | Comportamento inalterado | Comportamento inalterado ✅ |

## Riscos e mitigação

| Risco | Mitigação |
|---|---|
| O campo sumir por outro motivo (bug, render tardio) | Risco desprezível: outros campos são preenchidos antes de `filling_environment`, garantindo que a página já está renderizada nesse ponto. O log de debug facilita diagnóstico caso ocorra. |
| `self.config.initial_program` ser `None` | Mitigado com guard `(self.config.initial_program or '')`. |

## Como validar (passo a passo)

1. **Cenário principal (release ≥ 2610 + SIGAADV):**
   - Ambiente Protheus na release 2610+.
   - Executar `Setup("SIGAADV", ...)`.
   - Verificar que a inicialização **não** trava até o timeout e que o log de debug aparece com a mensagem de skip.

2. **Cenário de regressão (release < 2610 + SIGAADV):**
   - Ambiente Protheus em release < 2610.
   - Executar `Setup("SIGAADV", ...)`.
   - Verificar que o campo de ambiente é preenchido normalmente.

3. **Cenário de regressão (outro programa inicial):**
   - Executar `Setup("SIGAFAT", ...)`.
   - Verificar que o campo de ambiente é preenchido normalmente.

## Pendências conhecidas

- Testes unitários automatizados para o novo `elif` não foram incluídos neste PR. Recomenda-se endereçar em sprint seguinte.
