### PR TITLE
Route SetLateralMenu Through Router

### DIFF
--- a/tir/main.py
+++ b/tir/main.py
@@ -53,6 +53,7 @@ class Webapp():
         subscribe('route.program', self.__router.Program)
         subscribe('route.set_program', self.__router.set_program)
         subscribe('route.set_log_info', self.__router.set_log_info)
+        subscribe('route.set_lateral_menu', self.__router.SetLateralMenu)
         
         subscribe('webapp.setup', self.__webapp.Setup)
         subscribe('webapp.log_error', self.__webapp.log_error)

--- a/tir/technologies/core/router.py
+++ b/tir/technologies/core/router.py
@@ -126,7 +126,7 @@ class Router:
         else:
             # poui
             drv.SetLateralMenu(menu_itens=menu_itens, program_name=program_name, 
-                               module=module)
+                               module=module, save_input=save_input)
 
     def ChangeEnvironment(self, date: str = "", group: str = "", branch: str = "", module: str = "") -> None:
         """Change environment settings."""

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5388,12 +5388,17 @@ class PouiInternal(Base):
         :type program_desc: str
         :param module: Module abbreviation used to differentiate routines with the same name. - **Default:** "" (empty string)
         :type module: str
+        :param save_input: Controls whether routine metadata should be persisted in `config`/`log`.
+                   Set to **False** for internal navigations that must not overwrite the current execution context.
+                   - **Default:** True
+        :type save_input: bool
 
         Usage:
 
         >>> # Calling the method:
         >>> self.Program("MATA020")
         >>> self.Program("CRDA200", module="CRD")
+        >>> self.Program(program_desc="About", save_input=False)
         """
 
         if save_input:
@@ -5599,6 +5604,10 @@ class PouiInternal(Base):
         :type program_name: str
         :param module: Module abbreviation used to differentiate routines with the same name. - **Default:** "" (empty string)
         :type module: str
+        :param save_input: Forwarded to `Program()` to control if the navigation should persist routine metadata in `config`/`log`.
+                   Use **False** for temporary/internal menu navigation.
+                   - **Default:** True
+        :type save_input: bool
         """
         
         if not program_name:

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5376,7 +5376,7 @@ class PouiInternal(Base):
         return len(list(soup.select(term)))
 
 
-    def Program(self, program_name: str = "", program_desc: str = "", module: str = ""):
+    def Program(self, program_name: str = "", program_desc: str = "", module: str = "", save_input: bool = True):
         """
         [Internal]
 
@@ -5396,9 +5396,10 @@ class PouiInternal(Base):
         >>> self.Program("CRDA200", module="CRD")
         """
 
-        self.config.routine_type = 'Program'
-        self.config.routine = program_name
-        self.config.routine_module = module
+        if save_input:
+            self.config.routine_type = 'Program'
+            self.config.routine = program_name
+            self.config.routine_module = module
 
         if self.config.log_info_config:
             self.set_log_info_config()
@@ -5407,7 +5408,7 @@ class PouiInternal(Base):
             if not self.log.release:
                 self.log_error_newlog()
 
-        if not self.log.program:
+        if not self.log.program and save_input:
             self.log.program = program_name
 
         self.set_program(program_name, program_desc, module)
@@ -5589,7 +5590,7 @@ class PouiInternal(Base):
         self.close_coin_screen()
 
 
-    def SetLateralMenu(self, menu_itens: str, program_name:str = '', module: str = '') -> None:        
+    def SetLateralMenu(self, menu_itens: str, program_name:str = '', module: str = '', save_input: bool = True) -> None:        
         """Navigate through New Home menu context and open a routine.
 
         :param menu_itens: Menu path used as fallback to derive the routine description.
@@ -5608,9 +5609,9 @@ class PouiInternal(Base):
             )
             
             program_desc = menu_itens.split('>')[-1].strip()
-            self.Program(program_desc=program_desc)
+            self.Program(program_desc=program_desc, save_input=save_input)
         else:
-            self.Program(program_name=program_name, module=module)
+            self.Program(program_name=program_name, module=module, save_input=save_input)
 
 
     def _click_dropdown(self, label, subitems, position):

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -1728,7 +1728,8 @@ class WebappInternal(Base):
         else:
             term_dialog = '.tmodaldialog'
 
-        self.SetLateralMenu(self.language.menu_about, save_input=False)
+        from tir.technologies.core.events import emit
+        emit('route.set_lateral_menu', self.language.menu_about, save_input=False)
         self.wait_element(term=term_dialog, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container="body")
         self.wait_until_to(expected_condition = "presence_of_all_elements_located", element = term_dialog, locator= By.CSS_SELECTOR)
 
@@ -3757,10 +3758,10 @@ class WebappInternal(Base):
 
 
             if self.config.routine:
+                from tir.technologies.core.events import emit
                 if self.config.routine_type == 'SetLateralMenu':
-                    self.SetLateralMenu(self.config.routine, save_input=False)
+                    emit('route.set_lateral_menu', self.config.routine, save_input=False)
                 elif self.config.routine_type == 'Program':
-                    from tir.technologies.core.events import emit
                     emit('route.set_program', self.config.routine)
 
     def wait_user_screen(self):
@@ -9148,10 +9149,10 @@ class WebappInternal(Base):
 
         if not self.tmenu_screen:
             logger().debug(f"Re-open menu on screen: {self.tmenu_screen}")
+            from tir.technologies.core.events import emit
             if ">" in self.config.routine:
-                self.SetLateralMenu(self.config.routine, save_input=False)
+                emit('route.set_lateral_menu', self.config.routine, save_input=False)
             else:
-                from tir.technologies.core.events import emit
                 emit('route.program', self.config.routine, self.config.routine_module)
 
         self.tmenu_screen = None
@@ -9191,7 +9192,9 @@ class WebappInternal(Base):
                     pass
 
             self.Setup("SIGACFG", self.config.date, self.config.group, self.config.branch, self.config.module, save_input=False)
-            self.SetLateralMenu(self.config.parameter_menu if self.config.parameter_menu else self.language.parameter_menu, save_input=False)
+            from tir.technologies.core.events import emit
+            emit('route.set_lateral_menu', self.config.parameter_menu if self.config.parameter_menu else self.language.parameter_menu, save_input=False,
+                 program_name='CFGX017')
 
             self.wait_element(term=".ttoolbar, wa-toolbar, wa-panel", scrap_type=enum.ScrapType.CSS_SELECTOR)
             self.wait_element_timeout(term="img[src*=bmpserv1]", scrap_type=enum.ScrapType.CSS_SELECTOR, timeout=5.0, step=0.5)
@@ -9249,10 +9252,10 @@ class WebappInternal(Base):
             self.Setup(self.config.initial_program, self.config.date, self.config.group, self.config.branch, self.config.module, save_input=not self.config.autostart)
 
             if not self.tmenu_screen:
+                from tir.technologies.core.events import emit
                 if ">" in self.config.routine:
-                    self.SetLateralMenu(self.config.routine, save_input=False)
+                    emit('route.set_lateral_menu', self.config.routine, save_input=False)
                 else:
-                    from tir.technologies.core.events import emit
                     emit('route.program', self.config.routine, self.config.routine_module)
         else:
             stack = next(iter(list(map(lambda x: x.function, filter(lambda x: re.search('tearDownClass', x.function), inspect.stack())))), None)
@@ -11976,7 +11979,8 @@ class WebappInternal(Base):
                     pass
 
             self.Setup("SIGACFG", self.config.date, self.config.group, self.config.branch, self.config.module, save_input=False)
-            self.SetLateralMenu(self.config.procedure_menu if self.config.procedure_menu else self.language.procedure_menu, save_input=False)
+            from tir.technologies.core.events import emit
+            emit('route.set_lateral_menu', self.config.procedure_menu if self.config.procedure_menu else self.language.procedure_menu, save_input=False)
 
             self.wait_element(term=".ttoolbar, wa-toolbar, wa-panel, wa-tgrid", scrap_type=enum.ScrapType.CSS_SELECTOR)
             
@@ -12032,10 +12036,10 @@ class WebappInternal(Base):
             self.Setup(self.config.initial_program, self.config.date, self.config.group, self.config.branch, self.config.module, save_input=not self.config.autostart)
 
             if not self.tmenu_screen:
+                from tir.technologies.core.events import emit
                 if ">" in self.config.routine:
-                    self.SetLateralMenu(self.config.routine, save_input=False)
+                    emit('route.set_lateral_menu', self.config.routine, save_input=False)
                 else:
-                    from tir.technologies.core.events import emit
                     emit('route.program', self.config.routine, self.config.routine_module)
         else:
             stack = next(iter(list(map(lambda x: x.function, filter(lambda x: re.search('tearDownClass', x.function), inspect.stack())))), None)
@@ -12139,7 +12143,8 @@ class WebappInternal(Base):
 
             #Access Schedule environment
             self.Setup("SIGACFG", self.config.date, self.config.group, self.config.branch, self.config.module, save_input=False)
-            self.SetLateralMenu(self.language.schedule_menu, save_input=False)
+            from tir.technologies.core.events import emit
+            emit('route.set_lateral_menu', self.language.schedule_menu, save_input=False)
 
             #Wait show grid
             self.wait_element_timeout(term=self.grid_selectors["new_web_app"], scrap_type=enum.ScrapType.CSS_SELECTOR,
@@ -12167,10 +12172,10 @@ class WebappInternal(Base):
                        self.config.branch, self.config.module, save_input=not self.config.autostart)
 
             if not self.tmenu_screen:
+                from tir.technologies.core.events import emit
                 if ">" in self.config.routine:
-                    self.SetLateralMenu(self.config.routine, save_input=False)
+                    emit('route.set_lateral_menu', self.config.routine, save_input=False)
                 else:
-                    from tir.technologies.core.events import emit
                     emit('route.set_program', self.config.routine)
 
             self.tmenu_screen = None


### PR DESCRIPTION
## Contexto
Este PR alinha o comportamento de `SetLateralMenu` ao fluxo de roteamento já utilizado por `Program`.

Antes da alteração, chamadas de `Program` já passavam por `route.program`, permitindo ao roteador decidir entre WebApp (home antiga) e POUI (home nova), conforme configuração.

No entanto, `SetLateralMenu` ainda era chamado diretamente no WebApp (`self`), o que podia forçar execução no WebApp mesmo em cenários onde a navegação da home deveria ocorrer pelo POUI.

Além disso, o conceito de `save_input` foi propagado para o `Program` do POUI, permitindo navegações internas sem sobrescrever metadados de contexto de execução.

## O que foi alterado
- Assinatura de rota adicionada para navegação lateral:
  - `route.set_lateral_menu` registrado em `Webapp._subscribe_routes`.
- Ajuste no roteador:
  - `Router.SetLateralMenu` agora encaminha `save_input` para `SetLateralMenu` do POUI.
- Ajustes no POUI:
  - `PouiInternal.Program` agora recebe `save_input: bool = True`.
  - Quando `save_input=False`, os metadados de rotina não são persistidos em `config`/`log`.
  - `PouiInternal.SetLateralMenu` agora recebe e repassa `save_input` para `Program`.
- Ajustes nos pontos de chamada do WebApp:
  - Substituição de chamadas diretas `self.SetLateralMenu(...)` por `emit('route.set_lateral_menu', ...)` nos fluxos afetados (log info, parâmetros/procedures/schedule e reabertura de rotina após setup).
  - Na chamada de `parameter_screen`, foi adicionado `program_name='CFGX017'`, que é o nome da rotina acessada para realizar a troca de parâmetros no sistema.
- Documentação:
  - Atualização das docstrings no POUI (`Program` e `SetLateralMenu`) para descrever o comportamento de `save_input`.

## Impacto no fluxo anterior
- Fluxo anterior:
  - `WebappInternal` chamava `SetLateralMenu` diretamente, acoplando a execução à implementação WebApp.
- Fluxo atual:
  - `WebappInternal` emite `route.set_lateral_menu`, e o `Router` decide WebApp vs POUI com base em `config.new_home`.
- Refinamento de comportamento:
  - No POUI, `Program` pode executar sem persistir metadados de rotina quando `save_input=False`.

## Riscos e mitigação
### Risco identificado
- Dependência do event bus para roteamento de `SetLateralMenu` (subscriber precisa estar registrado via `main`).

### Decisão para este PR
- Não será adicionado fallback neste momento, pois a arquitetura esperada sempre passa por `main`.

### Mitigação
- Manter o registro de rotas centralizado em `Webapp._subscribe_routes`.
- Validar os fluxos em ambientes com `new_home=True` e `new_home=False`.
- Documentação atualizada para explicitar a semântica de `save_input` no POUI.

## Como validar (passo a passo)
1. Executar um cenário com `new_home=false` usando fluxo que chama `SetLateralMenu`.
2. Confirmar que a navegação ocorre via WebApp como antes.
3. Executar um cenário com `new_home=true` usando fluxo que chama `SetLateralMenu`.
4. Confirmar que o roteamento segue para POUI e abre a rotina esperada.
5. Acionar fluxos que chamam navegação com `save_input=False` (ex.: navegações internas/About/CFG).
6. Confirmar que os metadados de rotina não são sobrescritos no contexto POUI quando `save_input=False`.
7. Executar uma chamada normal de `Program` e confirmar manutenção do comportamento padrão (`save_input=True`).

## Checklist de testes
- [x] Regressão de navegação de menu na home legada (`new_home=false`)
- [x] Regressão de navegação de menu na nova home (`new_home=true`)
- [x] Validação de comportamento `save_input=False` no `Program` do POUI
- [x] Validação dos fluxos auxiliares de parâmetros/procedures/schedule

## Pendências conhecidas
- Testes automatizados de regressão para os cenários críticos de roteamento não serão adicionados nesta iteração.
- Não foi adicionado fallback explícito para ausência de subscriber de rota nesta iteração.