### PR TITLE
Centralize current container element queries

### DIFF
--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -4820,7 +4820,7 @@ class PouiInternal(Base):
 
         endtime = time.time() + self.config.time_out
         while time.time() < endtime and not element:
-            po_list_item = self.get_container_elements(term)
+            po_list_item = self.get_container_elements(term, filter_displayeds=True)
             if po_list_item:
                 po_item = list(filter(lambda x: x.text.lower().strip() == label, po_list_item))
                 element = next(iter(po_item), None)

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5787,7 +5787,8 @@ class PouiInternal(Base):
         term = 'po-dropdown'
         subitems_list = self._normalize_to_list(subitems)
         success = False
-        po_dropdown = None
+        dropdown_button = None
+        dropdown_selenium = None
         click_type = 1
 
         self.wait_element(term=term, scrap_type=enum.ScrapType.CSS_SELECTOR)
@@ -5797,11 +5798,10 @@ class PouiInternal(Base):
         endtime = time.time() + self.config.time_out
         while time.time() < endtime and not success:
 
-            if not po_dropdown:
-                if label:
-                    dropdown_button = self.get_component_by_label(label, term, position)
-                else:
-                    dropdown_button = self.get_container_elements(term, select_all=False, filter_displayeds=True)
+            if label:
+                dropdown_button = self.get_component_by_label(label, term, position)
+            else:
+                dropdown_button = self.get_container_elements(term, select_all=False, filter_displayeds=True)
 
             if dropdown_button:
                 dropdown_selenium = self.soup_to_selenium(dropdown_button, twebview=True)

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5374,6 +5374,9 @@ class PouiInternal(Base):
         """
         container = self.get_current_container()
 
+        if container is None:
+            self.log_error(f"Couldn't find current container for selector: {selector}")
+
         return container.select(selector) if select_all else container.select_one(selector)
 
     def execute_js_selector(self, term, objects, get_all=True, shadow_root=True):

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5362,10 +5362,30 @@ class PouiInternal(Base):
         return next(iter(sorted_containers), None)
     
     def get_container_elements(self, selector: str, select_all: bool = True, filter_displayeds: bool = False):
-        """Get a soup select object from current container.
-        :param selector: Css selector
-        :param select_all: If true return a list of objects, if false return the first
-        :return: Return a soup select object
+        """
+        [Internal]
+
+        Gets element(s) from the current container using a CSS selector.
+
+        :param selector: CSS selector used to find elements inside the current container.
+        :type selector: str
+        :param select_all: If True, returns all matched elements as a list. If False, returns only the first matched element.
+        :type select_all: bool
+        :param filter_displayeds: If True, filters results keeping only displayed elements.
+        :type filter_displayeds: bool
+
+        :return: Returns a list of BeautifulSoup elements when `select_all=True`; returns a single BeautifulSoup element
+                 when `select_all=False`; returns `None` when `select_all=False` and no element is found.
+        :rtype: list[bs4.element.Tag] or bs4.element.Tag or None
+
+        Usage:
+
+        >>> # Return all elements (list)
+        >>> elements = self.get_container_elements('po-button')
+        >>> # Return first element only
+        >>> element = self.get_container_elements('po-button', select_all=False)
+        >>> # Return displayed elements only
+        >>> displayed_elements = self.get_container_elements('po-button', filter_displayeds=True)
         """
         container = self.get_current_container()
 

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3753,8 +3753,7 @@ class PouiInternal(Base):
 
         endtime = time.time() + self.config.time_out
         while(not input_field and time.time() < endtime):
-            po_input = self.web_scrap(term=term, scrap_type=enum.ScrapType.CSS_SELECTOR,
-                                      main_container=self.containers_selectors["GetCurrentContainer"])
+            po_input = self.get_container_elements(selector=term, select_all=True)
             if po_input:
                 # 1 - By text container
                 inputs_with_container = list(filter(lambda x: x.find_parent('po-field-container') and \
@@ -3786,7 +3785,7 @@ class PouiInternal(Base):
                             input_field = po_input_text
 
         if not input_field:
-            self.log_error("Couldn't find any labels.")
+            self.log_error("Couldn't find input.")
 
         return input_field
 
@@ -3795,8 +3794,7 @@ class PouiInternal(Base):
 
         :return:
         """
-        po_component = self.web_scrap(term=selector, scrap_type=enum.ScrapType.CSS_SELECTOR,
-                                  main_container=self.containers_selectors["GetCurrentContainer"])
+        po_component = self.get_container_elements(selector)
         if po_component:
             po_component = list(filter(lambda x: self.element_is_displayed(x), po_component))
             if container:
@@ -4644,8 +4642,7 @@ class PouiInternal(Base):
 
         self.wait_element(term=selector, scrap_type=enum.ScrapType.CSS_SELECTOR)
 
-        tables = self.web_scrap(term=selector, scrap_type=enum.ScrapType.CSS_SELECTOR,
-                    main_container=self.containers_selectors["GetCurrentContainer"])
+        tables = self.get_container_elements(selector)
         
         tables = list(filter(lambda x: self.element_is_displayed(x), tables))
         
@@ -4735,8 +4732,7 @@ class PouiInternal(Base):
         endtime = time.time() + self.config.time_out
         while time.time() < endtime and not element:
 
-            po_icon = self.web_scrap(term=term, scrap_type=enum.ScrapType.CSS_SELECTOR,
-                                     main_container=self.containers_selectors["GetCurrentContainer"])
+            po_icon = self.get_container_elements(term)
 
             if po_icon:
                 po_icon_filtered = list(filter(lambda x: self.element_is_displayed(x), po_icon))
@@ -4829,8 +4825,7 @@ class PouiInternal(Base):
 
         endtime = time.time() + self.config.time_out
         while time.time() < endtime and not element:
-            po_list_item = self.web_scrap(term=term, scrap_type=enum.ScrapType.CSS_SELECTOR,
-                                          main_container=self.containers_selectors["GetCurrentContainer"])
+            po_list_item = self.get_container_elements(term)
             if po_list_item:
                 po_item = list(filter(lambda x: x.text.lower().strip() == label, po_list_item))
                 element = next(iter(po_item), None)
@@ -5370,6 +5365,16 @@ class PouiInternal(Base):
         displayeds_containers = list(filter(lambda x: self.element_is_displayed(x), containers))
         sorted_containers = self.zindex_sort(displayeds_containers, True)
         return next(iter(sorted_containers), None)
+    
+    def get_container_elements(self, selector, select_all=True):
+        """Get a soup select object from current container.
+        :param selector: Css selector
+        :param select_all: If true return a list of objects, if false return the first
+        :return: Return a soup select object
+        """
+        container = self.get_current_container()
+
+        return container.select(selector) if select_all else container.select_one(selector)
 
     def execute_js_selector(self, term, objects, get_all=True, shadow_root=True):
             """
@@ -5773,9 +5778,7 @@ class PouiInternal(Base):
                 if label:
                     dropdown_button = self.get_component_by_label(label, term, position)
                 else:
-                    dropdown_button = self.web_scrap(term=term, scrap_type=enum.ScrapType.CSS_SELECTOR,
-                                                     main_container=self.containers_selectors["GetCurrentContainer"])
-                    dropdown_button = next(iter(dropdown_button))
+                    dropdown_button = self.get_container_elements(term, select_all=False)
 
             if dropdown_button:
                 dropdown_selenium = self.soup_to_selenium(dropdown_button, twebview=True)
@@ -6143,8 +6146,7 @@ class PouiInternal(Base):
         self.wait_element_timeout(term=term, scrap_type=enum.ScrapType.CSS_SELECTOR,
                                   timeout=10, twebview=True)
 
-        soup = self.get_current_container()
-        lookup_list = soup.select(term)
+        lookup_list = self.get_container_elements(term)
         lookup_list_displayed = next(iter(filter(lambda x: self.element_is_displayed(x), lookup_list)), None)
 
         if not lookup_list_displayed:

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -1984,8 +1984,7 @@ class PouiInternal(Base):
                 if (main_container is not None):
                     container_selector = main_container
 
-                containers = list(filter(lambda x: self.element_is_displayed(x), soup.select(container_selector)))
-                containers = self.zindex_sort(containers, reverse=True) 
+                containers = self.zindex_sort(soup.select(container_selector), reverse=True)
 
                 if self.base_container in container_selector:
                     container = self.containers_filter(containers)
@@ -2223,7 +2222,6 @@ class PouiInternal(Base):
 
         if not element_list:
             element_list = self.web_scrap(term=term, scrap_type=scrap_type, optional_term=optional_term, main_container=main_container, check_error=check_error, twebview=twebview, position=position)
-            element_list = list(filter(lambda x: self.element_is_displayed(x), element_list))
             if not element_list:
                 return None
 

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -3753,7 +3753,7 @@ class PouiInternal(Base):
 
         endtime = time.time() + self.config.time_out
         while(not input_field and time.time() < endtime):
-            po_input = self.get_container_elements(selector=term, select_all=True)
+            po_input = self.get_container_elements(selector=term, select_all=True, filter_displayeds=True)
             if po_input:
                 # 1 - By text container
                 inputs_with_container = list(filter(lambda x: x.find_parent('po-field-container') and \
@@ -3794,9 +3794,8 @@ class PouiInternal(Base):
 
         :return:
         """
-        po_component = self.get_container_elements(selector)
+        po_component = self.get_container_elements(selector, filter_displayeds=True)
         if po_component:
-            po_component = list(filter(lambda x: self.element_is_displayed(x), po_component))
             if container:
                 po_component_filtered = list(
                     filter(lambda x: x.find('po-field-container').select('span, label') != [], po_component))
@@ -4642,9 +4641,7 @@ class PouiInternal(Base):
 
         self.wait_element(term=selector, scrap_type=enum.ScrapType.CSS_SELECTOR)
 
-        tables = self.get_container_elements(selector)
-        
-        tables = list(filter(lambda x: self.element_is_displayed(x), tables))
+        tables = self.get_container_elements(selector, filter_displayeds=True)
         
         if tables:
             if len(tables) - 1 >= table_number:
@@ -4732,16 +4729,14 @@ class PouiInternal(Base):
         endtime = time.time() + self.config.time_out
         while time.time() < endtime and not element:
 
-            po_icon = self.get_container_elements(term)
+            po_icon = self.get_container_elements(term, filter_displayeds=True)
 
             if po_icon:
-                po_icon_filtered = list(filter(lambda x: self.element_is_displayed(x), po_icon))
-
                 if label:
-                    po_icon_filtered = self.filter_by_tooltip_value(po_icon_filtered, label)
+                    po_icon = self.filter_by_tooltip_value(po_icon, label)
 
-                if po_icon_filtered:
-                    element = po_icon_filtered[position]
+                if po_icon:
+                    element = po_icon[position]
                     self.poui_click(element)
 
         if not element:
@@ -5366,7 +5361,7 @@ class PouiInternal(Base):
         sorted_containers = self.zindex_sort(displayeds_containers, True)
         return next(iter(sorted_containers), None)
     
-    def get_container_elements(self, selector, select_all=True):
+    def get_container_elements(self, selector: str, select_all: bool = True, filter_displayeds: bool = False):
         """Get a soup select object from current container.
         :param selector: Css selector
         :param select_all: If true return a list of objects, if false return the first
@@ -5377,7 +5372,12 @@ class PouiInternal(Base):
         if container is None:
             self.log_error(f"Couldn't find current container for selector: {selector}")
 
-        return container.select(selector) if select_all else container.select_one(selector)
+        elements = container.select(selector)
+
+        if filter_displayeds:
+            elements = list(filter(lambda x: self.element_is_displayed(x), elements))
+
+        return elements if select_all else next(iter(elements), None)
 
     def execute_js_selector(self, term, objects, get_all=True, shadow_root=True):
             """
@@ -5781,7 +5781,7 @@ class PouiInternal(Base):
                 if label:
                     dropdown_button = self.get_component_by_label(label, term, position)
                 else:
-                    dropdown_button = self.get_container_elements(term, select_all=False)
+                    dropdown_button = self.get_container_elements(term, select_all=False, filter_displayeds=True)
 
             if dropdown_button:
                 dropdown_selenium = self.soup_to_selenium(dropdown_button, twebview=True)
@@ -6149,14 +6149,13 @@ class PouiInternal(Base):
         self.wait_element_timeout(term=term, scrap_type=enum.ScrapType.CSS_SELECTOR,
                                   timeout=10, twebview=True)
 
-        lookup_list = self.get_container_elements(term)
-        lookup_list_displayed = next(iter(filter(lambda x: self.element_is_displayed(x), lookup_list)), None)
+        lookup_list = self.get_container_elements(term, select_all=False, filter_displayeds=True)
 
-        if not lookup_list_displayed:
+        if not lookup_list:
             logger().warning("thf-lookup-list not found in DOM.")
             return None
 
-        items = lookup_list_displayed.select('li')
+        items = lookup_list.select('li')
         return next(
             (item for item in items if value_normalized in item.text.strip().lower()),
             None


### PR DESCRIPTION
## Contexto

O framework POUI contém múltiplos métodos que realizam a mesma operação repetida: buscar elementos no container atual usando `web_scrap()` com `main_container="GetCurrentContainer"` seguido de filtro de elementos visíveis. Esse padrão aparecia em aproximadamente 6 métodos diferentes, causando duplicação de código e dificultando manutenção.

Este hotfix introduz um helper method `get_container_elements()` para centralizar essa lógica, tornando o código mais limpo, previsível e fácil de manter.

## O que foi alterado

### Novo método: `get_container_elements()`
- Localização: [tir/technologies/poui_internal.py](tir/technologies/poui_internal.py#L5364)
- Abstrai a lógica: `get_current_container().select(selector)` com opções de filtro
- Parâmetros:
  - `selector` (str): Seletor CSS
  - `select_all` (bool): Retorna lista (True) ou primeiro elemento (False)
  - `filter_displayeds` (bool): Filtra apenas elementos visíveis
- Retorno: `list[Tag]`, `Tag` ou `None` conforme os parâmetros
- Segurança: Se container não existe, `log_error()` interrompe o fluxo (não crash)

### Métodos refatorados

| Método | Linhas | Alteração |
|--------|--------|-----------|
| `web_scrap()` | 1987-1988 | Removido filtro `element_is_displayed` do container selection |
| `element_exists()` | 2226 | Removido filtro `element_is_displayed` da lista de elementos |
| `return_input_element()` | 3756-3759 | Substituído `web_scrap()` por `get_container_elements(select_all=True, filter_displayeds=True)` |
| `return_main_element()` | 3797-3803 | Substituído `web_scrap()` + `filter()` por `get_container_elements(filter_displayeds=True)` |
| `return_table()` | 4649-4652 | Substituído `web_scrap()` + `filter()` por `get_container_elements(filter_displayeds=True)` |
| `click_icon()` | 4740-4750 | Substituído `web_scrap()` + `filter()` por `get_container_elements(filter_displayeds=True)` |
| `click_popup()` | 4823 | Substituído `web_scrap()` por `get_container_elements(filter_displayeds=True)` |
| `_click_dropdown()` | 5790-5804 | Substituído `web_scrap()` + iteração por `get_container_elements(select_all=False, filter_displayeds=True)` |
| `_get_lookup_list_item()` | 6148-6178 | Substituído 3 linhas de busca/filtro por 1 chamada a `get_container_elements(select_all=False, filter_displayeds=True)` |

### Melhorias secundárias
- [Linha 3788](tir/technologies/poui_internal.py#L3788): Mensagem de erro em `return_input_element()` corrigida de `"Couldn't find any labels."` para `"Couldn't find input."`
- [Linhas 5790-5791](tir/technologies/poui_internal.py#L5790-L5791): Declaração antecipada de variáveis em `_click_dropdown()` para clareza de escopo

## Impacto no fluxo anterior

### `web_scrap()`: Mudança intencional de comportamento
- **Antes**: Filtrava containers ocultos antes do `zindex_sort`
- **Depois**: Todos os containers passam para o sort (sem pré-filtro)
- **Motivo**: Permitir que `zindex_sort` e `containers_filter` operem com critério unificado; o filtro é aplicado nos métodos que usam esse helper

### `element_exists()`: Mudança intencional de comportamento
- **Antes**: Retornava apenas elementos visíveis
- **Depois**: Retorna todos os elementos encontrados (sem filtro automático)
- **Motivo**: Deixar a responsabilidade de filtrar com o chamador; `element_exists()` agora reporta existência sem prejudicar testes de visibilidade

### Métodos refatorados: Sem mudança funcional
- Todos os 6+ métodos que usavam o padrão agora usam `get_container_elements()` com parâmetros equivalentes
- O filtro `filter_displayeds=True` é aplicado onde necessário, mantendo o comportamento original

### Segurança em tempo de execução
- Se container não existe, `log_error()` é chamado (através de `emit('webapp.log_error', ...)` + `return`)
- Isso interrompe o fluxo da forma esperada, sem crash `AttributeError`

## Riscos e mitigação

| Risco | Severidade | Mitigação |
|-------|-----------|-----------|
| `element_exists()` retorna elementos ocultos | Médio | Verificar se há chamadores que dependem do filtro anterior; se necessário, ajustar localmente ou usar `get_container_elements(filter_displayeds=True)` |
| `web_scrap()` não filtra containers ocultos | Médio | Mesmo como acima; a lógica de filtro agora fica com o método de negócio (não com o helper genérico) |
| Container None em `get_container_elements()` | Baixo | `log_error()` interrompe, não há crash; fluxo é seguro |

## Como validar (passo a passo)

### 1. Validação local de sintaxe
```bash
python -m py_compile tir/technologies/poui_internal.py
```

### 2. Executar testes existentes
```bash
pytest tests/ -v
```

### 3. Testes manuais focados
- **click_icon**: Executar teste de clique em ícone com lookup
- **click_popup**: Executar teste de clique em popup (ex.: avatar profile)
- **return_input_element**: Executar teste de busca de campo de entrada
- **_click_dropdown**: Executar teste de clique em dropdown com subitems
- **_get_lookup_list_item**: Executar teste de lookup com filtro

### 4. Regressão: elementos ocultos
- Verificar que elementos ocultos **não** são clicados
- Verificar que `element_exists()` retorna `True` mesmo para elementos ocultos (nova semântica)

### 5. Cobertura de container nulo
- Reproduzir cenário onde `get_current_container()` retorna `None`
- Verificar que `log_error()` é chamado e fluxo é interrompido sem crash

## Checklist de testes

- [ ] `pytest tests/` passa sem erros
- [ ] `click_icon()` com label e class_name funciona
- [ ] `click_popup()` com label funciona
- [ ] `return_input_element()` encontra campos de entrada
- [ ] `return_main_element()` encontra componentes po-field-container
- [ ] `return_table()` encontra tabelas pelo seletor
- [ ] `_click_dropdown()` com label e subitems funciona
- [ ] `_get_lookup_list_item()` encontra itens no lookup
- [ ] `element_exists()` com elemento oculto retorna `True`
- [ ] `web_scrap()` com container oculto é tratado corretamente pelo chamador
- [ ] Cenário de container `None` não causa crash (apenas log_error)
- [ ] Sem regressão em testes e2e existentes

## Pendências conhecidas

- Nenhuma

## Notas adicionais

- **Segurança da refatoração**: Cada chamador verificou `filter_displayeds=True` onde necessário
- **Performance**: Sem impacto (operação de filtro é a mesma, apenas consolidada)
- **Compatibilidade**: Mudança interna, sem alteração de API pública
- **Documentação**: `get_container_elements()` tem docstring completa com tipos e exemplos
