### PR TITLE
Refactor dropdown element retrieval to use get_container_elements method

### DIFF
--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5838,8 +5838,7 @@ class PouiInternal(Base):
 
         po_dropdown_label = None
 
-        po_dropdown = self.web_scrap(term=selector, scrap_type=enum.ScrapType.CSS_SELECTOR,
-                                     main_container=self.containers_selectors["GetCurrentContainer"])
+        po_dropdown = self.get_container_elements(selector, filter_displayeds=True)
         if po_dropdown:
             po_dropdown_label = list(filter(lambda x: self.filter_label_element(label.strip(), x, position),
                                             po_dropdown))


### PR DESCRIPTION
Ajuste para trocar o método de scrap do método ClickDropdown, para que pegue do container atual.
Foi identificado como colateral na fila da TIR_DEVELOP | 20260603 | 12.1.2610 na rotina ACDA130.