### PR TITLE
Add blocked-container fallback for field lookup

### DIFF
--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -1630,7 +1630,8 @@ class Base(unittest.TestCase):
 
         non_blocked_elements = elements
 
-        # Only filter out blocked elements if 'WaitProcessing' is not in the stack
+        # Filter blocked elements only when WaitProcessing is not in the stack
+        # and blocked-container filtering is enabled.
         if not self.search_stack('WaitProcessing') and self.filter_blocked_containers:
             non_blocked_elements = list(filter(lambda x: hasattr(x, 'attr') and 'blocked' not in x.attrs, elements))
 

--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -139,6 +139,7 @@ class Base(unittest.TestCase):
         self.config.log_file = False
         self.tmenu_out_iframe = False
         self.twebview_context = False
+        self.filter_blocked_containers = True
 
         if autostart:
             self.Start()
@@ -1630,7 +1631,7 @@ class Base(unittest.TestCase):
         non_blocked_elements = elements
 
         # Only filter out blocked elements if 'WaitProcessing' is not in the stack
-        if not self.search_stack('WaitProcessing'):
+        if not self.search_stack('WaitProcessing') and self.filter_blocked_containers:
             non_blocked_elements = list(filter(lambda x: hasattr(x, 'attr') and 'blocked' not in x.attrs, elements))
 
         if isinstance(non_blocked_elements, list):

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -3497,11 +3497,12 @@ class WebappInternal(Base):
         """
         endtime = time.time() + self.config.time_out
         element =  None
+        try_containers_blocked = False
 
         if re.match(r"\w+(_)", field) or name_attr:
             position -= 1
 
-        while(time.time() < endtime and not element):
+        while(not element):
             if re.match(r"\w+(_)", field) or name_attr:
                 element_list = self.web_scrap(f"[name$='{field}']", scrap_type=enum.ScrapType.CSS_SELECTOR)
                 if element_list and len(element_list) -1 >= position:
@@ -3511,6 +3512,18 @@ class WebappInternal(Base):
                     element = self.web_scrap(field, scrap_type=enum.ScrapType.TEXT, label=True, input_field=input_field, direction=direction, position=position)
                 else:
                     element = next(iter(self.web_scrap(field, scrap_type=enum.ScrapType.TEXT, label=True, input_field=input_field, direction=direction, position=position)), None)
+
+            if element:
+                break
+            
+            if time.time() > endtime and not try_containers_blocked:
+                self.filter_blocked_containers = False
+                try_containers_blocked = True
+            
+            elif time.time() > endtime and try_containers_blocked:
+                break
+
+        self.filter_blocked_containers = True
 
         if element:
             if not self.webapp_shadowroot():
@@ -8410,12 +8423,22 @@ class WebappInternal(Base):
                     class_term = ".ui-button.ui-dialog-titlebar-close[title='Close']"
                 if  class_term in term:
                     return False
-                self.restart_counter += 1
-                logger().debug(f'wait_element doesn\'t found term: {term}')
-                if presence:
-                    self.log_error(f"Element '{term}' not found!")
+                
+                # Fallback: Tenta encontrar sem filtrar os containers (apenas uma vez)
+                self.filter_blocked_containers = False
+                ele_without_filter = self.element_exists(term, scrap_type, position, optional_term, 
+                                                          main_container, check_error, twebview, second_term)
+
+                if (presence and ele_without_filter) or (not presence and not ele_without_filter):
+                    logger().debug(f'Element finded with out blocked filters')
                 else:
-                    self.log_error(f"Unexpected element '{term}' found!")
+                    self.filter_blocked_containers = True
+                    self.restart_counter += 1
+                    logger().debug(f'wait_element doesn\'t found term: {term}')
+                    if presence:
+                        self.log_error(f"Element '{term}' not found!")
+                    else:
+                        self.log_error(f"Unexpected element '{term}' found!")
 
         presence_endtime = time.time() + 10
         if presence:
@@ -8442,6 +8465,8 @@ class WebappInternal(Base):
                         pass
                     except StaleElementReferenceException:
                         pass
+                    
+        self.filter_blocked_containers = True
 
 
     def wait_element_timeout(self, term, scrap_type=enum.ScrapType.TEXT, timeout=5.0, step=0.1, presence=True, position=0, optional_term=None, main_container=".tmodaldialog,.ui-dialog, wa-dialog, body", check_error=True, twebview=False):

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -8424,13 +8424,13 @@ class WebappInternal(Base):
                 if  class_term in term:
                     return False
                 
-                # Fallback: Tenta encontrar sem filtrar os containers (apenas uma vez)
+                # Fallback: retry once without filtering blocked containers.
                 self.filter_blocked_containers = False
                 ele_without_filter = self.element_exists(term, scrap_type, position, optional_term, 
                                                           main_container, check_error, twebview, second_term)
 
                 if (presence and ele_without_filter) or (not presence and not ele_without_filter):
-                    logger().debug(f'Element finded with out blocked filters')
+                    logger().debug("Element found without blocked-container filtering.")
                 else:
                     self.filter_blocked_containers = True
                     self.restart_counter += 1

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -3286,9 +3286,19 @@ class WebappInternal(Base):
 
             logger().info(f"Filling element: {field}")
 
-            if self.filter_blocked_containers:
-                if not element or not self.element_is_displayed(element):
-                    continue
+            if not element:
+                continue
+
+            blocked_container = element.find_parent(
+                lambda tag: (
+                    tag.name == 'wa-dialog'
+                    or ('class' in tag.attrs and ('tmodaldialog' in tag['class'] or 'ui-dialog' in tag['class']))
+                ) if hasattr(tag, 'attrs') else False
+            )
+            container_is_blocked = hasattr(blocked_container, 'attrs') and 'blocked' in blocked_container.attrs
+
+            if self.filter_blocked_containers and not container_is_blocked and not self.element_is_displayed(element):
+                continue
 
 
             self.filter_blocked_containers = True
@@ -3526,6 +3536,8 @@ class WebappInternal(Base):
             
             elif time.time() > endtime and try_containers_blocked:
                 break
+
+        self.filter_blocked_containers = True
 
         if element:
             if not self.webapp_shadowroot():

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -3286,8 +3286,12 @@ class WebappInternal(Base):
 
             logger().info(f"Filling element: {field}")
 
-            if not element or not self.element_is_displayed(element):
-                continue
+            if self.filter_blocked_containers:
+                if not element or not self.element_is_displayed(element):
+                    continue
+
+
+            self.filter_blocked_containers = True
 
             main_element = element
             multiget = "dict-tmultiget"
@@ -3522,8 +3526,6 @@ class WebappInternal(Base):
             
             elif time.time() > endtime and try_containers_blocked:
                 break
-
-        self.filter_blocked_containers = True
 
         if element:
             if not self.webapp_shadowroot():


### PR DESCRIPTION
## 1. Contexto

Foi identificado um cenário em que, após ações de pesquisa (ex.: rotina TJURPESQAND no CT006), alguns containers permanecem bloqueados além do timeout esperado.
Com isso, a busca de elementos pode falhar mesmo quando o elemento existe na tela, causando erro por timeout.

A proposta deste PR é adicionar fallback com impacto mínimo no comportamento já existente.

## 2. O que foi alterado

- Adicionado controle global de filtro de containers bloqueados (`self.filter_blocked_containers`) em inicialização de base.
- Ajustada a filtragem de elementos bloqueados para respeitar o novo controle (`return_non_blocked_elements`).
- Em `get_field()`:
  - mantida busca normal até timeout;
  - ao estourar timeout, tenta uma nova busca sem filtrar containers bloqueados;
  - após o fluxo, o flag é restaurado para `True`.
- Em `input_value()`:
  - inclusão de guarda para `element is None` antes de qualquer uso;
  - avaliação de bloqueio no **container pai** (`.tmodaldialog,.ui-dialog,wa-dialog`) em vez de avaliar bloqueio no próprio elemento;
  - `element_is_displayed()` só é exigido quando o filtro está ativo e o container pai não está bloqueado.
- Em `wait_element()`:
  - ao exceder timeout, há tentativa adicional sem filtro de container bloqueado antes de registrar erro;
  - ao final, o flag é restaurado para `True`.

## 3. Impacto no fluxo anterior

- **Antes:** falha por timeout encerrava o fluxo sem nova tentativa em containers bloqueados.
- **Agora:** em pontos críticos (`get_field` e `wait_element`), ocorre uma tentativa de fallback sem filtro de bloqueio antes de falhar.
- **Efeito esperado:** redução de falso negativo em cenários onde o container permanece com `blocked` mais tempo que o timeout padrão.

Não houve alteração de assinatura de métodos públicos em `tir/main.py`.

## 4. Riscos e mitigação

### Riscos
- Uso de estado global (`self.filter_blocked_containers`) entre métodos pode introduzir efeitos colaterais se não houver restauração correta.
- Fluxos com timeout podem ficar mais permissivos, mascarando problemas de sincronização em cenários específicos.

### Mitigações aplicadas
- Restauração explícita do flag para `True` ao final de `get_field()` e `wait_element()`.
- Guarda de `element is None` em `input_value()` para evitar exceções de runtime.
- Validação de bloqueio no container pai para aderência ao comportamento real da UI.

### Mitigação recomendada (pós-merge)
- Encapsular fallback de `wait_element()` com `try/finally` para garantir restauração do flag mesmo em exceções inesperadas.

## 5. Como validar (passo a passo)

1. Executar um cenário que historicamente sofre com timeout por container bloqueado (ex.: fluxo de pesquisa da rotina citada no contexto).
2. Confirmar que, após timeout da busca principal, o fallback sem filtro permite localizar o elemento.
3. Validar que preenchimento (`SetValue`/`input_value`) continua funcional quando:
   - container não bloqueado;
   - container bloqueado (fallback).
4. Validar `wait_element()` nos dois modos:
   - `presence=True` (elemento deve existir);
   - `presence=False` (elemento não deve existir).
5. Confirmar que chamadas subsequentes não herdam estado indevido de filtro (flag restaurado).

## 6. Checklist de testes

- [X] Cenário com container não bloqueado mantém comportamento legado.
- [ ] Cenário com container bloqueado encontra elemento via fallback.
- [ ] `input_value()` não gera erro quando `element` é `None`.
- [ ] `wait_element()` valida fallback antes de erro final em timeout.
- [ ] `get_field()` restaura `self.filter_blocked_containers` ao final.

## 7. Pendências conhecidas

- Atualização de docstrings dos métodos alterados para refletir com precisão o novo comportamento de fallback.
- Inclusão/expansão de testes automatizados específicos de regressão para os novos caminhos de fallback.