### PR TITLE
Fix container lookup and grid checkbox flow

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -6142,8 +6142,10 @@ class WebappInternal(Base):
                 logger().debug('The container has been changed.')
                 return True
 
-            element_td, _ = self._refresh_element_td(grid_number=grid_number,
-                                                     matches_values=matches_values)
+            if matches_values:
+                element_td, _ = self._refresh_element_td(grid_number=grid_number,
+                                                        matches_values=matches_values)
+            
             if not element_td:
                 break
 
@@ -7155,6 +7157,7 @@ class WebappInternal(Base):
 
         cell_filled = False
         selenium_column = None
+        checkbox_grid = None
         current_layers = lambda : self.check_layers(layer_selector)
         initial_layers = current_layers()
 
@@ -7165,37 +7168,53 @@ class WebappInternal(Base):
                 selenium_column, _ = self.get_grid_cell(column=column, grid_number=grid_number, row=row, field_to_label=field_to_label, position=column_position, duplicate_fields=duplicate_fields)
                 current_container = self.get_current_container()
                 current_container_id = current_container.get("id")
+                checkbox_grid = self._return_checkbox_grid(selenium_column)
 
             if selenium_column:
-                cell_opened = self.open_cell(field, initial_layers, element=selenium_column)
-                selenium_input = lambda: self.get_grid_input_element()
+                # Tratamento para quando o clique for para inputs do tipo checkbox
+                if isinstance(user_value, bool) and checkbox_grid:
+                    cell_filled = self.performing_additional_click(checkbox_grid, grid_number)
 
-                if selenium_input():
-                    if isinstance(selenium_input(), Select):
-                        cell_filled = self.select_combo(selenium_input(), user_value)
-                        time.sleep(1)
-                        # if modal opened close it
-                        if current_layers() > initial_layers:
-                            self.send_keys(selenium_column, Keys.TAB)
-                    else:
-                        if cell_opened:
-                            self.process_input_element(field, selenium_input, user_value, value_type, initial_layers)
-                            self.wait_element_fill(selenium_column, field_one, value_type, timeout=10)
+                else:
+                    cell_opened = self.open_cell(field, initial_layers, element=selenium_column)
+                    selenium_input = lambda: self.get_grid_input_element()
 
-                        # if modal/dialog still opened, skip check value
-                        if self.element_exists(term="wa-dialog", scrap_type=enum.ScrapType.CSS_SELECTOR,
-                                               position=initial_layers + 1, main_container="body", check_error=False):
-                            logger().info(
-                                "Dialog open, skipping value check, Check cell fill")
-                            return
-
-                        if check_value:
-                            cell_filled = self.compare_cell_value(selenium_column, field_one, value_type)
-                            if not cell_filled:
-                                self.search_for_errors()
+                    if selenium_input():
+                        if isinstance(selenium_input(), Select):
+                            cell_filled = self.select_combo(selenium_input(), user_value)
+                            time.sleep(1)
+                            # if modal opened close it
+                            if current_layers() > initial_layers:
+                                self.send_keys(selenium_column, Keys.TAB)
                         else:
-                            cell_filled = True
+                            if cell_opened:
+                                self.process_input_element(field, selenium_input, user_value, value_type, initial_layers)
+                                self.wait_element_fill(selenium_column, field_one, value_type, timeout=10)
 
+                            # if modal/dialog still opened, skip check value
+                            if self.element_exists(term="wa-dialog", scrap_type=enum.ScrapType.CSS_SELECTOR,
+                                                position=initial_layers + 1, main_container="body", check_error=False):
+                                logger().info(
+                                    "Dialog open, skipping value check, Check cell fill")
+                                return
+
+                            if check_value:
+                                cell_filled = self.compare_cell_value(selenium_column, field_one, value_type)
+                                if not cell_filled:
+                                    self.search_for_errors()
+                            else:
+                                cell_filled = True
+    
+    def _return_checkbox_grid(self, element):
+
+        try:
+            term = "div[style*='wfunchk_mdi.png'], div[style*='wfchk_mdi.png']"
+            checkbox_div = element.find_elements(By.CSS_SELECTOR, term)
+
+            return next(iter(checkbox_div), None)
+        except:
+            return None
+    
     def compare_cell_value(self, selenium_column, user_value, value_type=None):
         """Compares two values, ignoring formatting differences.
 
@@ -12379,7 +12398,17 @@ class WebappInternal(Base):
         :param select_all: If true return a list of objects, if false return the first
         :return: Return a soup select object
         """
-        container = self.get_current_container()
+
+        container = None
+
+        endtime = time.time() + self.config.time_out / 2
+        while time.time() < endtime and not container:
+            logger().debug('Looking for container')
+            container = self.get_current_container()
+            time.sleep(1)
+
+        if not container:
+            self.log_error('Container doesn''t found!')
 
         return container.select(selector) if select_all else container.select_one(selector)
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -19,6 +19,7 @@ from bs4 import BeautifulSoup, Tag
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support.ui import Select
 from tir.technologies.core import base
 from tir.technologies.core.log import Log, nump
@@ -7171,7 +7172,7 @@ class WebappInternal(Base):
                 checkbox_grid = self._return_checkbox_grid(selenium_column)
 
             if selenium_column:
-                # Tratamento para quando o clique for para inputs do tipo checkbox
+                # Handle checkbox input elements when the value is a boolean
                 if isinstance(user_value, bool) and checkbox_grid:
                     cell_filled = self.performing_additional_click(checkbox_grid, grid_number)
 
@@ -7205,7 +7206,20 @@ class WebappInternal(Base):
                             else:
                                 cell_filled = True
     
-    def _return_checkbox_grid(self, element):
+    def _return_checkbox_grid(self, element: WebElement) -> WebElement | None:
+        """
+        [Internal]
+
+        Finds and returns a checkbox element within a grid cell if present.
+
+        Searches for checkbox elements using CSS selectors that match checkbox icon styles
+        in the grid cell. Returns the first checkbox element found or None if no checkbox exists.
+
+        :param element: Selenium element (grid cell) to search for a checkbox element.
+        :type element: WebElement
+        :return: The first checkbox element found, or None if no checkbox element exists.
+        :rtype: WebElement or None
+        """
 
         try:
             term = "div[style*='wfunchk_mdi.png'], div[style*='wfchk_mdi.png']"
@@ -12393,10 +12407,20 @@ class WebappInternal(Base):
 
 
     def get_container_selector(self, selector, select_all=True):
-        """Get a soup select object from current container.
-        :param selector: Css selector
-        :param select_all: If true return a list of objects, if false return the first
-        :return: Return a soup select object
+        """
+        [Internal]
+
+        Retrieves elements from the current container using a CSS selector with retry logic.
+
+        Attempts to retrieve the current container with a timeout, retrying every second.
+        If the container is not found after timeout, logs an error and attempts selection anyway.
+
+        :param selector: CSS selector to query within the container.
+        :type selector: str
+        :param select_all: If True, returns a list of all matching elements; if False, returns only the first match. - **Default:** True
+        :type select_all: bool
+        :return: A list of matching elements if select_all is True, or the first matching element if select_all is False.
+        :rtype: list or BeautifulSoup element
         """
 
         container = None

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -7174,7 +7174,8 @@ class WebappInternal(Base):
             if selenium_column:
                 # Handle checkbox input elements when the value is a boolean
                 if isinstance(user_value, bool) and checkbox_grid:
-                    cell_filled = self.performing_additional_click(checkbox_grid, grid_number)
+                    click_success = self.performing_additional_click(checkbox_grid, grid_number)
+                    cell_filled = click_success if check_value else True
 
                 else:
                     cell_opened = self.open_cell(field, initial_layers, element=selenium_column)


### PR DESCRIPTION
## 1) Contexto

Alterações:

- proteção na busca do container ativo antes de selecionar elementos;
- ajuste do fluxo de preenchimento em grid para campos checkbox (valor booleano);

Problemas observados na rotina **JURA163**:

- Erro em `get_container_selector()`:

  ```
  File "E:\Python312\Lib\site-packages\tir\technologies\webapp_internal.py", line 12384, in get_container_selector
      return container.select(selector) if select_all else container.select_one(selector)
             ^^^^^^^^^^^^^^^^^
  AttributeError: 'NoneType' object has no attribute 'select'
  ```

- No comando `SetValue` para grid, o fluxo entrava em looping marcando e desmarcando a checkbox.

## 2) O que foi alterado

- Inclusão de `WebElement` para tipagem explícita.
- Ajuste em `performing_additional_click()` para atualizar a célula via `_refresh_element_td()` **somente** quando `matches_values` for informado.
- Refatoração de `fill_grid_loop()`:
  - criação do fluxo específico para checkbox em grid quando `user_value` é booleano;
  - identificação do checkbox com novo método interno `_return_checkbox_grid()`;
  - uso de `performing_additional_click()` no caminho de checkbox;
  - regra de finalização no checkbox: `cell_filled = click_success if check_value else True`.
- Novo método interno `_return_checkbox_grid(element: WebElement) -> WebElement | None` com docstring e contrato de retorno.
- Fortalecimento de `get_container_selector()`:
  - passa a aguardar/retry do container por timeout;
  - faz log explícito de erro quando não encontra container dentro da janela.

## 3) Impacto no fluxo anterior

### Fluxo anterior
- `fill_grid_loop()` tratava o caminho geral de edição de célula, sem separar explicitamente checkbox booleano logo no início do bloco.
- `performing_additional_click()` tentava refresh de elemento sem condicional por `matches_values`.
- `get_container_selector()` assumia container imediato, sem retry dedicado.

### Fluxo novo
- `fill_grid_loop()` agora bifurca explicitamente:
  - **checkbox booleano**: executa clique adicional e valida conforme `check_value`;
  - **demais campos**: mantém fluxo anterior de abrir célula, preencher e validar.
- `performing_additional_click()` evita refresh indevido quando não há `matches_values`.
- `get_container_selector()` fica resiliente a latência de renderização/container.

## 4) Riscos e mitigação

### Riscos
- Mudança de fluxo no preenchimento de checkbox em grid pode alterar comportamento percebido em scripts de regressão.
- Em cenários com DOM muito instável, o retry de container pode aumentar tempo de execução até timeout.

### Mitigação
- Caminho não-checkbox permanece preservado na lógica principal.
- Regra com `check_value=False` evita loop desnecessário em checkbox (`cell_filled=True` direto).
- Erro de container agora fica explícito em log, facilitando diagnóstico.

## 5) Como validar (passo a passo)

1. Executar um cenário com `SetValue(..., grid=True)` em coluna de checkbox com `check_value=True`.
2. Confirmar que a marcação/desmarcação ocorre e que o fluxo finaliza sem timeout.
3. Repetir cenário de checkbox com `check_value=False` e validar que não há retry desnecessário.
4. Executar cenário de campo não-checkbox em grid para confirmar ausência de regressão no fluxo legado.
5. Simular tela com carregamento mais lento e validar que `get_container_selector()` aguarda container antes da seleção.
6. Verificar logs para mensagem de erro de container quando o elemento realmente não estiver disponível.

## 6) Checklist de testes

- [X] Checkbox em grid com `check_value=True`
- [ ] Checkbox em grid com `check_value=False`
- [X] Campo texto/número em grid (caminho não-checkbox)
- [ ] Regressão de `LoadGrid()` em rotina com múltiplas colunas
- [X] Cenário com latência de renderização de container
- [ ] Verificação de logs para diagnóstico de erro