### PR TITLE
fix(poui_internal): reduce timeouts for CFGX017 in set_program

### DIFF
--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5776,7 +5776,7 @@ class PouiInternal(Base):
                                 program_call=True, match_mode=match_mode)
         
         # Code block for "Change module"
-        endtime = time.time() + 30
+        endtime = time.time() + (30 if program_name != 'CFGX017' else 5)
         while time.time() < endtime:
 
             if self.language.change_module in self.get_current_container().text:
@@ -5799,7 +5799,7 @@ class PouiInternal(Base):
 
         # -- Trecho de código temporário --
         btn_confirmar = lambda: self.get_current_DOM().select(confirm_term)
-        endtime = time.time() + 120
+        endtime = time.time() + (120 if program_name != 'CFGX017' else 5)
         while time.time() < endtime:
             logger().debug(f'Waiting for the confirm button.')
 
@@ -5826,7 +5826,8 @@ class PouiInternal(Base):
 
         success = (ele_hidden) and (wtb_before != wtb_after)
 
-        self.close_after_routine(program_name)
+        if program_name != 'CFGX017':
+            self.close_after_routine(program_name)
 
         if not success:
             message = "Couldn't set the program."

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5754,6 +5754,7 @@ class PouiInternal(Base):
         match_mode = 1 if module or program_desc else 3     
         ele_hidden = None
         wtb_after = None    
+        parameter_routine = 'CFGX017'
 
         self.wait_element(term=search_term, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container='body')
         
@@ -5776,7 +5777,7 @@ class PouiInternal(Base):
                                 program_call=True, match_mode=match_mode)
         
         # Code block for "Change module"
-        endtime = time.time() + (30 if program_name != 'CFGX017' else 5)
+        endtime = time.time() + (30 if program_name != parameter_routine else 5)
         while time.time() < endtime:
 
             if self.language.change_module in self.get_current_container().text:
@@ -5799,7 +5800,7 @@ class PouiInternal(Base):
 
         # -- Trecho de código temporário --
         btn_confirmar = lambda: self.get_current_DOM().select(confirm_term)
-        endtime = time.time() + (120 if program_name != 'CFGX017' else 5)
+        endtime = time.time() + (120 if program_name != parameter_routine else 5)
         while time.time() < endtime:
             logger().debug(f'Waiting for the confirm button.')
 
@@ -5826,7 +5827,7 @@ class PouiInternal(Base):
 
         success = (ele_hidden) and (wtb_before != wtb_after)
 
-        if program_name != 'CFGX017':
+        if program_name != parameter_routine:
             self.close_after_routine(program_name)
 
         if not success:


### PR DESCRIPTION
## 1. Contexto

A rotina **CFGX017** é utilizada exclusivamente para adição/edição de parâmetros do sistema. Por ser uma rotina de configuração, ela tem comportamento distinto das demais: não exibe mensagem de troca de módulo, não exibe botão de confirmação, e não requer o fechamento padrão realizado pelo `close_after_routine`. Com os timeouts originais (30s e 120s), o TIR ficava aguardando desnecessariamente condições que nunca ocorreriam para essa rotina, impactando diretamente o tempo de execução dos testes.

---

## 2. O que foi alterado

**Arquivo:** `tir/technologies/poui_internal.py`  
**Método:** `set_program`

| Trecho | Antes | Depois |
|--------|-------|--------|
| Timeout do loop "Change module" | `time.time() + 30` | `time.time() + (30 if program_name != CFGX017_PROGRAM else 5)` |
| Timeout do loop "Botão confirmar" | `time.time() + 120` | `time.time() + (120 if program_name != CFGX017_PROGRAM else 5)` |
| Chamada a `close_after_routine` | Sempre executada | Executada apenas quando `program_name != CFGX017_PROGRAM` |

---

## 3. Impacto no fluxo anterior

- **Para todos os outros programas:** sem nenhuma alteração de comportamento. Os timeouts e o `close_after_routine` continuam exatamente iguais.
- **Para o CFGX017:** os dois loops de espera passam a ter timeout de 5s (suficiente para entrar no loop, verificar que a condição não existe e sair imediatamente). O `close_after_routine` é ignorado, pois a rotina de parâmetros não gera os elementos que esse método aguarda/fecha.
- **Nenhuma assinatura pública foi alterada**, portanto nenhum script de QA existente é afetado.

---

## 4. Riscos e mitigação

| Risco | Severidade | Mitigação |
|-------|-----------|-----------|
| Timeout de 5s insuficiente em ambiente lento | Médio | O CFGX017 não exibe nenhuma das mensagens aguardadas; o loop sai na primeira iteração independentemente da latência do ambiente |
| Skip de `close_after_routine` deixar estado sujo | Médio | Confirmado pelo dev: a rotina de parâmetros não gera os modais/confirmações que `close_after_routine` trata, portanto o skip é seguro |

---

## 5. Como validar (passo a passo)

1. No `config.json` do ambiente de teste, definir a chave `ParameterUrl` como `false` — isso força o TIR a adicionar o parâmetro via interface (abrindo o CFGX017), e não via URL.
2. Executar uma rotina de teste que utilize os métodos `AddParameter` ou `SetParameters`. Usei como exemplo a ACDA030.
3. Verificar que a navegação até o CFGX017 ocorre sem timeout e sem erros no log.
4. Verificar que após a execução o ambiente está em estado limpo (sem modais abertos), e que o fluxo do script continua normalmente após a adição do parâmetro.
5. Executar um script com qualquer rotina que não use parâmetros e verificar que o comportamento permanece idêntico ao anterior (timeouts de 30s e 120s, `close_after_routine` executado normalmente).

---

## 6. Checklist de testes

- [x] `ParameterUrl` definido como `false` no `config.json` para forçar o caminho via interface
- [x] Rotina de teste com `AddParameter` ou `SetParameters` executada (ex.: ACDA030) — navegação até o CFGX017 ocorre sem timeout e sem erros no log
- [x] Ambiente em estado limpo após a execução do CFGX017 (sem modais abertos) e fluxo do script continua normalmente
- [x] Rotina sem uso de parâmetros executada e comportamento mantido idêntico ao anterior (timeouts de 30s e 120s, `close_after_routine` executado normalmente)

---

## 7. Pendências conhecidas

- Validação em ambientes com maior latência (cloud/CI) ainda não confirmada formalmente, mas o risco é baixo dado que as condições aguardadas nos loops simplesmente não ocorrem para o CFGX017.
