### PR TITLE
feat(webapp_internal): add double click retry logic to ClickTree method

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -9607,7 +9607,7 @@ class WebappInternal(Base):
                     label_serv1 = next(iter(img_serv1.parent.select('label')), None)
 
                 if label_serv1:
-                    self.ClickTree(label_serv1.text.strip())
+                    self.ClickTree(label_serv1.text.strip(), try_double_click=True)
                     self.wait_element_timeout(term="img[src*=bmpparam]", scrap_type=enum.ScrapType.CSS_SELECTOR, timeout=5.0, step=0.5)
                     container = self.get_current_container()
 
@@ -9623,7 +9623,7 @@ class WebappInternal(Base):
                     if img_param:
                         label_param = img_param if self.webapp_shadowroot() else next(iter(img_param.parent.select('label')), None)
 
-                        self.ClickTree(label_param.text.strip())
+                        self.ClickTree(label_param.text.strip(), try_double_click=True)
 
             if not label_param:
                 self.log_error(f"Couldn't find Icon")
@@ -10165,7 +10165,7 @@ class WebappInternal(Base):
         containers = soup.select(self.containers_selectors["AllContainers"])
         return containers
 
-    def ClickTree(self, treepath, right_click=False, position=1, tree_number=0):
+    def ClickTree(self, treepath, right_click=False, position=1, tree_number=0, try_double_click: bool = False):
         """
         Clicks on TreeView component.
 
@@ -10177,6 +10177,8 @@ class WebappInternal(Base):
         :type position: int
         :param tree_number: Tree position for cases where there is more than one tree on screen.
         :type tree_number: int
+        :param try_double_click: If True, after 3 single click attempts, tries 3 additional double click attempts using all ClickType variations. - **Default:** False
+        :type try_double_click: bool
 
         Usage:
 
@@ -10185,9 +10187,9 @@ class WebappInternal(Base):
         >>> # Right Click example:
         >>> oHelper.ClickTree("element 1 > element 2 > element 3", right_click=True)
         """
-        self.click_tree(treepath, right_click, position, tree_number)
+        self.click_tree(treepath, right_click, position, tree_number, try_double_click=try_double_click)
 
-    def click_tree(self, treepath, right_click, position, tree_number):
+    def click_tree(self, treepath, right_click, position, tree_number, try_double_click: bool = False):
         """
         [Internal]
         Take treenode and label to filter and click in the toggler element to expand the TreeView.
@@ -10277,11 +10279,20 @@ class WebappInternal(Base):
                                             self.wait_blocker()                                            
 
                                             is_element_acessible = lambda: not element_is_closed() if self.check_toggler(label_filtered, element) else element_is_selected()
-
                                             click_try = 0
-                                            while click_try < 3 and not is_element_acessible():
+                                            click_type = 1
+                                            max_tries = 6 if try_double_click else 3
+                                            while click_try < max_tries and not is_element_acessible():                                                
                                                 self.scroll_to_element(element_click())
-                                                element_click().click()
+                                                if click_try < 3:
+                                                    logger().debug('Trying to open with one click')
+                                                    self.click(element_click(), enum.ClickType.SELENIUM)
+                                                elif try_double_click:
+                                                    logger().debug(f'Trying to open with double click. ClickType: {click_type}')
+                                                    self.double_click(element_click(), enum.ClickType(click_type))
+                                                    click_type += 1
+                                                    if click_type > 3:
+                                                        click_type = 1
                                                 click_try += 1
 
                                             success = self.check_hierarchy(label_filtered, False) or is_element_acessible()
@@ -10309,12 +10320,12 @@ class WebappInternal(Base):
                                             click_try = 0
                                             while click_try < 3 and (element_is_closed() or not element_is_selected()):
                                                 if element_is_closed():
-                                                    element_click().click()
+                                                    self.click(element_click(), enum.ClickType.SELENIUM)
 
                                                 element_closed_click = self.execute_js_selector(".toggler, .lastchild, .data", element_click(), get_all=False)
 
                                                 if element_closed_click:
-                                                    element_closed_click.click()
+                                                    self.click(element_closed_click(), enum.ClickType.SELENIUM)
 
                                                 click_try += 1
                                             
@@ -10328,7 +10339,7 @@ class WebappInternal(Base):
                                     try:
                                         element_click = lambda: self.soup_to_selenium(element_class_item.parent)
                                         self.scroll_to_element(element_click())
-                                        element_click().click()
+                                        self.click(element_click(), enum.ClickType.SELENIUM)
                                         success = self.clicktree_status_selected(label_filtered) if last_item and not self.check_toggler(label_filtered, element_click()) else self.check_hierarchy(label_filtered)
                                     except:
                                         pass


### PR DESCRIPTION
Na task #CA-12397 do ryver foi informado que o processo para adicionar parâmetros no chrome não estava funcionando.
Ao testar o erro foi reproduzido localmente e identificado que necessita de um clique duplo até manualmente.
Portanto foi adicionado uma tratativa para que depois que tente 3 vezes apenas com um clique igual estava antes, tente 3 vezes com clique duplo.
Além disso, foi trocado o clique simples direto no elemento, para um método encapsulado que trata possíveis erros.
Foi testado nos navegadores Chrome e Firefox, nas release 2510 e 2610.