### PR TITLE
Fix: infinite loop in `Program` method and `IfExists` unable to detect blocked containers

### DIFF
--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -1632,7 +1632,7 @@ class Base(unittest.TestCase):
 
         # Filter blocked elements only when WaitProcessing is not in the stack
         # and blocked-container filtering is enabled.
-        if not self.search_stack('WaitProcessing') and self.filter_blocked_containers:
+        if not self.search_stack('WaitProcessing') and not self.search_stack('IfExists') and self.filter_blocked_containers:
             non_blocked_elements = list(filter(lambda x: hasattr(x, 'attr') and 'blocked' not in x.attrs, elements))
 
         if isinstance(non_blocked_elements, list):

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -1997,6 +1997,7 @@ class WebappInternal(Base):
             logger().debug(f'wa-dialog layers: {container_layers}')
 
         if not success:
+            self.restart_counter += 1
             self.log_error('Home screen not found!')     
         
         # wait trasitions between screens to avoid errors in layers number


### PR DESCRIPTION
## Contexto

Rotinas que utilizam `SIGATEC` como programa inicial possuem um processamento demorado após o `Setup` antes de chegarem à home screen. Esse comportamento expunha dois problemas distintos no TIR.

---

## Problema 1 — Loop infinito no método `Program`

O método `escape_to_main_menu`, chamado internamente pelo `Program`, não incrementava o `restart_counter` antes de acionar o `log_error`. Como resultado, quando a home screen não era encontrada (cenário comum no `SIGATEC` devido ao tempo de carregamento), o `log_error` chamava o `restart`, que por sua vez reexecutava o `Program` via `emit('route.set_program')`, gerando um loop infinito até timeout.

**Correção:** adicionado o incremento de `restart_counter` no `escape_to_main_menu` antes da chamada ao `log_error`, garantindo que após 3 tentativas o fluxo seja encerrado corretamente.

---

## Problema 2 — `IfExists` não detectava elementos em containers blocked

Para proteger scripts com `SIGATEC`, a recomendação é usar o seguinte padrão entre o `Setup` e o `Program`:

```python
if inst.oHelper.IfExists('Processando...'):
    inst.oHelper.WaitProcessing('Processando...')
```

Porém, o `IfExists` não encontrava o elemento enquanto o `WaitProcessing` encontrava imediatamente. A causa raiz é que o Protheus marca o container como `blocked` durante o processamento, e o TIR possui um mecanismo (`return_non_blocked_elements`) que filtra esses containers por padrão — com exceção explícita apenas para quando `WaitProcessing` estava na call stack.

Como o `IfExists` chama diretamente `WaitShow` sem passar por `WaitProcessing`, essa exceção não se aplicava, e o container bloqueado era filtrado antes de a busca ser executada.

**Correção:** adicionada a exceção para `IfExists` na condição de filtragem do `return_non_blocked_elements` em `base.py`:

```python
# Antes
if not self.search_stack('WaitProcessing') and self.filter_blocked_containers:

# Depois
if not self.search_stack('WaitProcessing') and not self.search_stack('IfExists') and self.filter_blocked_containers:
```

Com isso, tanto `WaitProcessing` quanto `IfExists` conseguem detectar elementos em containers bloqueados, mantendo o comportamento consistente entre os dois métodos.

---

Exemplo de rotinas afetadas:

- TECA190A
- TECA220
- TECA450
- TECA460
- TECA500
- TECC050
- TECA190D
- TECA203
- TECA470EST
- TECA480
- TECA700
- TECA999
- TECC020
- TECA120
- TECC010
