### PR TITLE
fix(webapp_internal): improve modal detection logic in combo selection

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -7409,7 +7409,7 @@ class WebappInternal(Base):
                             cell_filled = self.select_combo(selenium_input(), user_value)
                             time.sleep(1)
                             # if modal opened close it
-                            if current_layers() > initial_layers:
+                            if current_layers() == initial_layers + 1:
                                 self.send_keys(selenium_column, Keys.TAB)
                         else:
                             if cell_opened:


### PR DESCRIPTION
## 1. Contexto

Durante a automação da rotina **FINA040**, foi identificado que o preenchimento de um campo do tipo `select` (combo) em um grid estava gerando um **help inesperado** após a seleção do valor.

O TIR possui uma lógica em `fill_grid_loop` que, após preencher um campo combo, verifica se o dropdown ainda está aberto comparando a quantidade de layers da página antes e depois do preenchimento. Caso o número de layers tenha aumentado, era enviada a tecla **TAB** para fechar o dropdown.

O problema é que na FINA040 existe um `select` que, ao ser selecionado, abre um **container adicional** além do próprio dropdown. Com isso, o TAB era enviado para esse container secundário, provocando o help.

---

## 2. O que foi alterado

A lógica passa a enviar o TAB **somente quando exatamente 1 layer adicional estiver aberto** — ou seja, apenas o próprio dropdown do combo. Se mais de um layer adicional for detectado, entende-se que um container secundário foi aberto e o TAB **não é enviado**.

---

## 3. Impacto no fluxo anterior

| Cenário | Comportamento anterior | Novo comportamento |
|---|---|---|
| Select abre apenas o próprio dropdown (+1 layer) | TAB enviado ✅ | TAB enviado ✅ |
| Select abre dropdown + container adicional (+2 layers) | TAB enviado no container errado ❌ | TAB **não** enviado ✅ |
| `current_layers()` retorna `initial_layers + 2` ou mais por outro motivo | TAB enviado | TAB **não** enviado ⚠️ |

Nenhuma assinatura de método público em `tir/main.py` foi alterada — scripts existentes dos QAs **não são afetados**.

---

## 4. Riscos e mitigação

### ⚠️ Risco médio — Caso edge: `current_layers() > initial_layers + 1`

A nova condição (`== initial_layers + 1`) deixa de enviar o TAB em qualquer situação onde **mais de 1 layer adicional** esteja presente. Isso é correto para o cenário do FINA040, mas **pode causar regressão silenciosa** em rotinas onde dois ou mais layers são abertos após o `select_combo` e ainda assim o TAB seria necessário para fechar o combo corretamente.

**Mitigação adotada:** cobertura de testes em duas rotinas representativas (cenário com e sem container adicional). A validação ampla fica dependente da fila do SmartTest.

---

## 6. Checklist de testes

- [x] Campo `select` em grid que **abre container adicional** após seleção (FINA040 — 14 CTs)
- [x] Campo `select` em grid que **não abre container adicional** após seleção (MNTA420_02 — 10 CTs)
- [x] Outros tipos de campo no grid testados nas mesmas rotinas
- [ ] Fila completa do SmartTest *(pendente — necessário para descartar regressão em rotinas não mapeadas)*

