### PR TITLE
increase click verification delay timings

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -5073,7 +5073,7 @@ class WebappInternal(Base):
                         current_clicked_element = soup_element
 
                         # Small delay to ensure stability (avoids clicking during transitions)
-                        time.sleep(0.2)
+                        time.sleep(0.5)
 
                         if click_attempt == 1:
                             self.send_action(action=self.click, element=lambda: soup_element)
@@ -5100,7 +5100,7 @@ class WebappInternal(Base):
                     # Verification: waits up to 3s to detect click effect
                     verification_timeout = time.time() + 3
                     while time.time() < verification_timeout and not click_verified:
-                        time.sleep(0.1)
+                        time.sleep(0.5)
                         try:
                             # Check 1: Did the container change?
                             current_container = self.get_current_container()


### PR DESCRIPTION
- Increase pre-click delay from 0.2s to 0.5s to ensure stability during element transitions
- Increase click verification poll interval from 0.1s to 0.5s for more reliable state detection
- Improve reliability of click effect verification in ClickTree method

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Hotfix - Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Manual
- [ ] SmartTest

**Test Configuration**:
* Add your description.
