### PR TITLE
fix: prevent duplicate set_program call after restart in setUpClass

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -4635,7 +4635,7 @@ class WebappInternal(Base):
         # A flag é consumida (resetada) aqui para não interferir em chamadas futuras.
         if getattr(self, '_lateral_menu_set_by_restart', False):
             self._lateral_menu_set_by_restart = False
-            logger().info(f"Lateral menu '{menu_itens}' already set by restart, skipping.")
+            logger().debug(f"Lateral menu '{menu_itens}' already set by restart, skipping.")
             return
 
         self.wait_element(term=menu_term, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container="body")

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -1905,7 +1905,7 @@ class WebappInternal(Base):
             # The flag is consumed (reset) here so it only triggers once.
             if getattr(self, '_program_set_by_restart', False):
                 self._program_set_by_restart = False
-                logger().info(f"Program '{program_name}' already set by restart, skipping.")
+                logger().debug(f"Program '{program_name}' already set by restart, skipping.")
                 return
 
             self.wait_element(term=cget_term, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container="body")

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -3889,6 +3889,7 @@ class WebappInternal(Base):
                 from tir.technologies.core.events import emit
                 if self.config.routine_type == 'SetLateralMenu':
                     emit('route.set_lateral_menu', self.config.routine, save_input=False)
+                    self._lateral_menu_set_by_restart = True
                 elif self.config.routine_type == 'Program':
                     emit('route.set_program', self.config.routine)
                     self._program_set_by_restart = True
@@ -4629,6 +4630,13 @@ class WebappInternal(Base):
         menu_itens = list(map(str.strip, menu_itens.split(">")))
 
         self.escape_to_main_menu()
+
+        # Se o restart() já navegou o menu lateral via emit, pula o restante.
+        # A flag é consumida (resetada) aqui para não interferir em chamadas futuras.
+        if getattr(self, '_lateral_menu_set_by_restart', False):
+            self._lateral_menu_set_by_restart = False
+            logger().info(f"Lateral menu '{menu_itens}' already set by restart, skipping.")
+            return
 
         self.wait_element(term=menu_term, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container="body")
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -1901,6 +1901,13 @@ class WebappInternal(Base):
 
             self.escape_to_main_menu()
 
+            # If restart() already handled set_program via emit, skip the rest.
+            # The flag is consumed (reset) here so it only triggers once.
+            if getattr(self, '_program_set_by_restart', False):
+                self._program_set_by_restart = False
+                logger().info(f"Program '{program_name}' already set by restart, skipping.")
+                return
+
             self.wait_element(term=cget_term, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container="body")
 
             soup = self.get_current_DOM()
@@ -3884,6 +3891,7 @@ class WebappInternal(Base):
                     emit('route.set_lateral_menu', self.config.routine, save_input=False)
                 elif self.config.routine_type == 'Program':
                     emit('route.set_program', self.config.routine)
+                    self._program_set_by_restart = True
 
     def wait_user_screen(self):
 


### PR DESCRIPTION
## 1. Contexto

O TIR possui um mecanismo de recuperação automática chamado `restart()`, acionado quando o `log_error` é disparado durante a execução de um caso de teste. Esse mecanismo reinicia o browser, refaz o login, navega pelo ambiente e reabre a rotina configurada — seja via `emit('route.set_program', ...)` quando `routine_type == 'Program'`, seja via `emit('route.set_lateral_menu', ...)` quando `routine_type == 'SetLateralMenu'`.

O problema relatado ocorria especificamente quando o `log_error` era disparado dentro do `setUpClass`, comportamento observado na rotina **SGAA060**. Diferente do comportamento em um CT normal — onde o `assertTrue(False)` interrompe a execução imediatamente — no `setUpClass` a execução **continua** após o retorno do `restart()`. Com isso, o método original que estava na pilha de chamadas (`set_program` ou `SetLateralMenu`) retomava sua execução normalmente, executando novamente toda a lógica de navegação mesmo com a rotina já aberta pelo `restart()`. O resultado era um timeout de aproximadamente 6 minutos aguardando elementos que nunca apareceriam, causando falha em todo o setup da suite de testes.

---

## 2. Impacto no fluxo anterior

| Cenário | Comportamento anterior | Comportamento após o fix |
|---|---|---|
| CT normal (sem `log_error` no `setUpClass`) | `set_program()` / `SetLateralMenu()` executam integralmente | Inalterado — flags nunca são setadas nesse caminho |
| `log_error` no `setUpClass` com `routine_type == 'Program'` | `set_program()` executava duas vezes, causando timeout de ~6 min | `restart()` seta `_program_set_by_restart = True`; a segunda chamada retorna antecipadamente |
| `log_error` no `setUpClass` com `routine_type == 'SetLateralMenu'` | `SetLateralMenu()` executava duas vezes, mesmo problema | `restart()` seta `_lateral_menu_set_by_restart = True`; a segunda chamada retorna antecipadamente |

---

## 3. Riscos e mitigação

**Risco: acionamento indevido da flag em chamada posterior**
A flag é consumida (resetada) imediatamente na primeira leitura dentro de `set_program()` ou `SetLateralMenu()`. Isso garante que apenas a primeira chamada após o `restart()` seja bypassada. Chamadas subsequentes executam normalmente.

**Risco: flag inexistente na instância antes do primeiro `restart()`**
Mitigado pelo uso de `getattr(self, '_flag', False)`, que retorna `False` quando o atributo ainda não existe, sem lançar `AttributeError`.

**Fluxo normal de CTs**: não é impactado. As flags só são setadas dentro do `restart()`, que só é chamado na presença de erros.

---

## 4. Como validar (passo a passo)

1. Configurar um script com `setUpClass` que provoque um `log_error` durante o `escape_to_main_menu` (ou qualquer ponto anterior ao `wait_element` de `set_program` / `SetLateralMenu`)
2. **Cenário A** — `routine_type = 'Program'`: realizar uma chamada a `Program()` no `setUpClass`
3. **Cenário B** — `routine_type = 'SetLateralMenu'`: realizar uma chamada a `SetLateralMenu()` no `setUpClass`
4. Executar com a versão **anterior** ao fix e observar o timeout de ~6 minutos
5. Executar com a versão **após o fix** e verificar que:
   - O `restart()` reabre a rotina normalmente via `emit`
   - O log exibe a mensagem de bypass (`"already set by restart, skipping."`)
   - O método da pilha original retorna sem executar o fluxo de navegação
   - A suite de testes finaliza sem travar
6. Executar um CT normal (sem `log_error` no `setUpClass`) e verificar que o comportamento é idêntico ao anterior

---

## 5. Checklist de testes

- [x] Cenário com `log_error` no `setUpClass` e `routine_type == 'Program'` — validado com `webapp_shadowroot = True`
- [x] Fluxo normal de CT sem erro — sem regressão
- [x] Cenário com `log_error` no `setUpClass` e `routine_type == 'SetLateralMenu'` — fix aplicado, aguarda validação

---

## 6. Pendências conhecidas

- Docstrings de `restart()`, `set_program()` e `SetLateralMenu()` não foram atualizadas para documentar o comportamento das flags — deixado como pendência para não ampliar o escopo do fix.
