### PR TITLE
Fix grid cell click blocked by overlay layer

### DIFF
--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -234,6 +234,7 @@ class Base(unittest.TestCase):
             return False
         except ElementClickInterceptedException as e:
             logger().debug(e.msg)
+            return False
         except Exception as e:
             logger().debug(f"Warning click method Exception: {str(e)}")
             return False

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -6510,12 +6510,10 @@ class WebappInternal(Base):
         df, grid = self.grid_dataframe(grid_number=grid_number)
         sel_grid  = self.soup_to_selenium(grid)
         success = lambda: 'focus' in sel_grid.get_attribute('class')
-        clicked = None
 
         while count < 4 and not success():
             self.wait_blocker()
-            clicked = self.click(sel_grid, click_type=enum.ClickType(click_type))  
-
+            self.click(sel_grid, click_type=enum.ClickType(click_type))  
             count += 1
 
             if count == 3:

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -6506,14 +6506,20 @@ class WebappInternal(Base):
         [Internal]
         """
         count = 0
+        click_type = 2
         df, grid = self.grid_dataframe(grid_number=grid_number)
         sel_grid  = self.soup_to_selenium(grid)
         success = lambda: 'focus' in sel_grid.get_attribute('class')
-        while count < 3 and not success():
+        clicked = None
+
+        while count < 4 and not success():
             self.wait_blocker()
-            self.click(sel_grid, click_type=enum.ClickType.SELENIUM)
+            clicked = self.click(sel_grid, click_type=enum.ClickType(click_type))  
+
             count += 1
 
+            if count == 3:
+                click_type = 3
 
     def grid_dataframe(self, grid_number=0, wait=True, check_error=True, current_container=False, throw_error=True):
         """
@@ -8447,6 +8453,7 @@ class WebappInternal(Base):
         logger().info(f"Clicking on grid cell: {column}")
 
         grid_cell, _ = self.get_grid_cell(column=column, row=row_number, grid_number=grid_number, field_to_label=field_to_label)
+        self.set_grid_focus(grid_number)
         self.select_grid_cell(grid_cell)
 
     def filter_non_obscured(self, elements, grid_number):


### PR DESCRIPTION
## 1. Contexto

Foi relatado na task #CA-12603 (Ryver) uma quebra na rotina PLSA366. A investigação identificou que o método `ClickGridCell` não estava sendo efetivo, fazendo com que o próximo método `SetKey("Enter", grid=True, grid_number=2)` também tivesse efeito, gerando o erro `001 - [SetValue] Element 'BCD_CODPAG' not found!`.

A causa raiz é uma layer que fica na frente da grid e impede o clique de `ClickGridCell` — essa layer existe apenas na release 2610.

## 2. O que foi alterado

- **`ClickGridCell`**: agora chama `set_grid_focus()` antes de `select_grid_cell()`, para remover a layer que fica na frente da grid e garantir o foco antes de selecionar a célula.
- **`set_grid_focus`**: o método já fazia até 3 tentativas de clique usando apenas Selenium, o que não era efetivo para remover a layer em alguns cenários. Foi adicionada uma 4ª tentativa usando `ActionChains`, mantendo as 3 tentativas legadas com Selenium intactas (se der certo com Selenium, nem chega na tentativa com ActionChains).
- **`click()` (base.py)**: adicionado um `return False` explícito no branch de `ElementClickInterceptedException`, que antes retornava implicitamente `None`.

## 3. Impacto no fluxo anterior

- `set_grid_focus`: fluxo anterior — até 3 tentativas, todas com `ClickType.SELENIUM`. Fluxo novo — até 4 tentativas, sendo as 3 primeiras iguais ao legado e a 4ª com `ClickType.ACTIONCHAINS`.
- `ClickGridCell`: fluxo anterior — apenas `get_grid_cell` + `select_grid_cell`. Fluxo novo — `get_grid_cell` + `set_grid_focus` + `select_grid_cell`.
- `click()`: mudança apenas no valor de retorno (`None` → `False`) no branch de `ElementClickInterceptedException`; não há alteração no fluxo de exceções.

Nenhuma assinatura de método público (`tir/main.py`) foi alterada, portanto não há risco de quebra de contrato para scripts já escritos por QAs.

## 4. Riscos e mitigação

- **`ClickGridCell` agora depende de `set_grid_focus`**: esse método também é usado internamente por `SetFocus(field, grid_cell=True, ...)`. A mitigação é a validação pendente listada no checklist abaixo.
- **Latência adicional**: o `while count < 4` com `wait_blocker()` a cada iteração pode adicionar tempo de execução em `ClickGridCell` e `ClickBox` mesmo em telas sem a layer bloqueante (2510). Mitigado pela saída antecipada via `success()` quando o foco já é obtido nas primeiras tentativas.
- **Colaterais não mapeados**: possíveis colaterais (a) cenários de `ClickBox` que cheguem ao último tipo de clique e gerem efeito colateral, e (b) cenários de `ClickGridCell` sem a layer que cheguem ao clique via `ActionChains` sem necessidade. Mitigação: testes manuais nas releases 2510 e 2610 (ver checklist).

## 5. Como validar (passo a passo)

1. Executar a rotina **PLSA366** na release **2510** e confirmar que `ClickGridCell` continua funcionando normalmente (sem a layer bloqueante).
2. Executar a rotina **PLSA366** na release **2610** e confirmar que a layer é removida e o clique na célula é efetivo.
3. Executar a rotina **AGRA650** (usa `ClickBox`, que por sua vez usa `set_grid_focus`) na 2510 e na 2610, e confirmar que o comportamento permanece correto.
4. Confirmar que `AGRA650` também exercita `ClickGridCell` sem regressão.

## 6. Checklist de testes

- [x] Rotina **PLSA366** executada na release **2510** com esta alteração.
- [x] Rotina **PLSA366** executada na release **2610** com esta alteração.
- [x] Rotina **AGRA650** (uso de `ClickBox` → `set_grid_focus`) executada na release **2510**.
- [x] Rotina **AGRA650** (uso de `ClickBox` → `set_grid_focus`) executada na release **2610**.
- [x] Rotina **MATA119** (uso de `SetFocus` → `set_grid_focus`) executada na release **2510**.
- [x] Rotina **MATA119** (uso de `SetFocus` → `set_grid_focus`) executada na release **2610**.
