### PR TITLE
fix(webapp_internal): improve button element handling and timeout logic

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -730,7 +730,7 @@ class WebappInternal(Base):
         if self.webapp_shadowroot(shadow_root=shadow_root):
             button = lambda: button_element
         else:
-            button = lambda: self.driver.find_element(By.XPATH, xpath_soup(button_element))
+            button = lambda: self.soup_to_selenium(button_element, twebview=self.config.poui_login)
 
         if self.config.poui_login:
             self.switch_to_iframe()
@@ -5000,7 +5000,6 @@ class WebappInternal(Base):
             success = False
             endtime = time.time() + self.config.time_out
             starttime = time.time()
-            halftime = time.time() + (self.config.time_out / 2)
 
             if self.config.smart_test or self.config.debug_log:
                 logger().debug(f"***System Info*** Before Clicking on button:{button}")
@@ -5008,11 +5007,11 @@ class WebappInternal(Base):
 
             next_button = None
             while(time.time() < endtime and not soup_element):
-                # During the first half of the timeout, also require the element to be the
-                # topmost one at its center point (not intercepted by an overlay). After that,
-                # fall back to the legacy behavior (element_is_displayed only).
+                # Throughout the whole timeout, also require the element to be the topmost one
+                # at its center point (not intercepted by an overlay). The separate on_top
+                # filter is now enforced for the entire time_out instead of only the first half.
                 # The very first SetButton usage always skips this on_top check.
-                enforce_on_top = (not first_setbutton_use) and (time.time() < halftime)
+                enforce_on_top = (not first_setbutton_use) and (time.time() < endtime)
                 if self.webapp_shadowroot():
                     next_button = self.get_shadowroot_button(button, term_button, position, check_error)
 


### PR DESCRIPTION
- Replace xpath_soup with soup_to_selenium for consistent element conversion
- Remove unused halftime variable from button click timeout logic
- Update enforce_on_top condition to check against endtime instead of halftime
- Enforce overlay interception check for entire timeout duration instead of only first half
- Update comments to reflect new timeout behavior for on_top filter

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Hotfix - Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Manual
- [ ] SmartTest

**Test Configuration**:
* Add your description.
