### PR TITLE
Fix tab count to ignore hidden wa-tab-view panels

### DIFF
--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5871,7 +5871,8 @@ class PouiInternal(Base):
 
         self.wait_element(term=search_term, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container='body')
         
-        get_wtb = lambda: len(self.get_current_DOM().select('wa-tab-button'))
+        get_wtb = lambda: len(list(filter(lambda x: not 'hidden' in x.find_parent('wa-tab-view').attrs, 
+                                                    self.get_current_DOM().select('wa-tab-button'))))
         wtb_before = get_wtb()
 
         hide_element = next(iter(self.web_scrap(term=search_term, 

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5871,8 +5871,9 @@ class PouiInternal(Base):
 
         self.wait_element(term=search_term, scrap_type=enum.ScrapType.CSS_SELECTOR, main_container='body')
         
-        get_wtb = lambda: len(list(filter(lambda x: not 'hidden' in x.find_parent('wa-tab-view').attrs, 
-                                                    self.get_current_DOM().select('wa-tab-button'))))
+        get_wtb = lambda: len(list(filter(lambda x: x.find_parent('wa-tab-view') and 
+                                                    not 'hidden' in x.find_parent('wa-tab-view').attrs, 
+                                    self.get_current_DOM().select('wa-tab-button'))))
         wtb_before = get_wtb()
 
         hide_element = next(iter(self.web_scrap(term=search_term, 


### PR DESCRIPTION
## 1. Contexto

O método `set_program` (New Home, POUI) identifica se uma rotina foi aberta com sucesso comparando a quantidade de `wa-tab-button` na tela antes e depois de confirmar a abertura. Na Home ficam duas abas fixas; ao abrir uma rotina, uma terceira aba (da própria rotina) é adicionada.

**Padrão de reprodução do bug:** o erro seguia um padrão específico de execução — em um CT (caso de teste) a rotina era acessada e depois encerrada (saída da rotina, retornando à Home); no CT seguinte, a mesma sequência de acesso era repetida a partir da Home. Nesse segundo acesso (ou em acessos subsequentes ao padrão "entrar → sair → entrar de novo"), as abas da Home ficavam ocultas (`hidden`), e o método `get_wtb()` contava 3 abas tanto antes quanto depois — o que fazia o TIR concluir, erroneamente, que a rotina não havia sido aberta.

Ou seja, o comportamento de manter abas ocultas no DOM parece se manifestar apenas em um subconjunto de rotinas, não em todas — o que tornava o bug intermitente e mais difícil de isolar.

## 2. O que foi alterado

Em `tir/technologies/poui_internal.py`, dentro de `set_program`, a lambda `get_wtb` foi ajustada para não contar mais **todos** os `wa-tab-button` do DOM, e sim apenas os que:
1. possuem um ancestral `wa-tab-view`; **e**
2. esse ancestral não contém o atributo `hidden`.

## 3. Impacto no fluxo anterior

- **Antes:** `get_wtb()` contava todos os `wa-tab-button` existentes no DOM, independentemente de estarem visíveis ou ocultos.
- **Depois:** `get_wtb()` conta apenas os `wa-tab-button` visíveis (ancestral `wa-tab-view` existente e sem `hidden`).
- A mudança preserva o restante do fluxo de `set_program` (clique no item da lista, confirmação de módulo, espera pelo botão de confirmação, fechamento de telas pós-rotina), afetando apenas o critério de contagem usado para validar se uma nova aba foi aberta.

## 4. Riscos e mitigação

- **Risco identificado na review:** caso algum `wa-tab-button` legítimo (inclusive o da própria rotina recém-aberta) não possua ancestral `wa-tab-view`, ele passaria a ser excluído da contagem silenciosamente, o que poderia zerar `get_wtb()` em ambos os momentos (antes/depois) e fazer `set_program` falhar sempre.
  - **Mitigação/validação:** testes manuais confirmaram que o fix não introduziu esse problema nas rotinas testadas (PLSUA550 e MATA014), cobrindo tanto o padrão "entrar/sair/entrar" quanto o acesso direto simples.
- **Ponto em aberto:** como o comportamento de abas ocultas parece afetar apenas um subconjunto de rotinas, ainda não há uma lista fechada de quais rotinas reproduzem o padrão. Recomenda-se observar a próxima fila de execução completa para identificar eventuais regressões em rotinas não testadas manualmente.

## 5. Como validar (passo a passo)

1. Executar um CT que acesse uma rotina pela New Home e saia dela (retornando à Home).
2. No CT seguinte, repetir o acesso à mesma rotina (ou a uma rotina com o mesmo padrão) a partir da Home.
3. Confirmar que `set_program` identifica corretamente a abertura da rotina (sem erro de "Couldn't set the program.").
4. Repetir o teste com uma rotina de acesso direto (sem padrão entrar/sair), como MATA014, para garantir que o caminho simples não regrediu.

## 6. Checklist de testes

- [x] Rotina com padrão "entrar → sair → entrar novamente" que apresentava o bug (LOJA850, LOJA350 — task CA-12636 e CA-12638).
- [x] Rotina com o mesmo padrão que já passava antes do fix (PLSUA550) — continuou passando.
- [x] Rotina com acesso direto, sem o padrão entrar/sair (MATA014) — continuou funcionando.
- [ ] Execução completa da fila de testes de regressão para mapear eventuais rotinas não cobertas manualmente.
- [ ] Teste unitário automatizado para a lógica de filtro de `get_wtb()` (não implementado neste PR; lambda foi mantida como está).

## 7. Pendências conhecidas

- A lógica de contagem permanece implementada como lambda inline dentro de `set_program` (decisão do dev: será mantida em lambda, sem extração para método nomeado).
- Não há lista definitiva de quais rotinas reproduzem o padrão de abas ocultas; o comportamento parece intermitente e específico de um subconjunto ainda não mapeado.
- Sem cobertura de teste automatizado (unitário) para a nova lógica de filtro — validação feita via testes manuais/execução de CTs específicos.
