### PR TITLE
Improve F3 action reliability with click/key retries

### DIFF
--- a/tir/main.py
+++ b/tir/main.py
@@ -546,21 +546,15 @@ class Webapp():
         """
         self.__webapp.take_screenshot(filename)
 
-    def F3(self, field, name_attr=False,send_key=False):
+    def F3(self, field: str, name_attr: bool = False, send_key: bool = False) -> None:
         """
-        Do the standard query(F3)
-        
-        this method:
+        Opens the field's lookup (query) search window, used to search and select a value for a field.
 
-            1.Search the field
-            2.Search icon "lookup"
-            3.Click()
-
-        :param term: The term that must be searched.
-        :type  term: str
-        :param name_attr: True: searchs element by name.
-        :type  name_attr: bool
-        :param send_key: True: try open standard search field send key F3.
+        :param field: The label or the internal name of the field to search.
+        :type field: str
+        :param name_attr: Set to True to search the field by its internal name instead of its label. - **Default:** False
+        :type name_attr: bool
+        :param send_key: Set to True to open the search window by sending the F3 key instead of clicking the lookup icon. - **Default:** False
         :type send_key: bool
 
         Usage:
@@ -568,13 +562,13 @@ class Webapp():
         >>> # To search using a label name:
         >>> oHelper.F3("Cód")
         >>> #------------------------------------------------------------------------
-        >>> # To search using the name of input:
-        >>> oHelper.F3(field='A1_EST',name_attr=True)
+        >>> # To search using the internal name of a field:
+        >>> oHelper.F3(field='A1_EST', name_attr=True)
         >>> #------------------------------------------------------------------------
-        >>> # To search using the name of input and do action with a key:
-        >>> oHelper.F3(field='A1_EST',name_attr=True,send_key=True)
+        >>> # To search using the internal name and opening with the F3 key instead of a click:
+        >>> oHelper.F3(field='A1_EST', name_attr=True, send_key=True)
         """
-        self.__webapp.standard_search_field( field, name_attr, send_key )
+        self.__webapp.standard_search_field(field, name_attr, send_key)
     
     def SetupTSS(self, initial_program="", environment=""):
         """

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -2057,49 +2057,67 @@ class WebappInternal(Base):
         >>> # To search using the name of input and do action with a key:
         >>> oHelper.F3(field='A1_EST',name_attr=True,send_key=True)
         """
-        endtime = self.config.time_out + time.time()
 
-        try:
-            #wait element
-            if name_attr:
-                self.wait_element(term=f"[name$='{term}']", scrap_type=enum.ScrapType.CSS_SELECTOR)
-            else:
-                self.wait_element(term)
-            # find element
-            element = self.get_field(term,name_attr).find_parent() if not self.webapp_shadowroot() else self.get_field(term,name_attr)
-            if not(element):
-                raise Exception("Couldn't find element")
+        success = False
+        attempt = 0
 
-            logger().debug("Field successfully found")
-            if(send_key):
-                input_field = lambda: self.driver.find_element(By.XPATH, xpath_soup(element))
-                self.set_element_focus(input_field())
-                container = self.get_current_container()
-                self.send_keys(input_field(), Keys.F3)
-            else:
+        logger().info(f"Looking for field {term} for F3 action...")
+
+        if name_attr:
+            self.wait_element(term=f"[name$='{term}']", scrap_type=enum.ScrapType.CSS_SELECTOR)
+        else:
+            self.wait_element(term)
+        
+        element = self.get_field(term,name_attr)
+        
+        if not(element):
+            self.log_error(f"Couldn't find field {term} for F3 action")
+
+        logger().info("Field found successfully!")
+        logger().debug("Trying to open new container...")
+
+        container_id_before = self.get_current_container().get('id')
+        container_id_after = container_id_before
+        endtime = time.time() + self.config.time_out
+
+        while (time.time() < endtime and not success):
+
+            if attempt > 0:
+                logger().debug("Trying again...")
+            
+            if (not send_key and attempt % 2 == 0):
+                logger().debug("Clicking on search icon")
                 icon = next(iter(element.select("img[src*=fwskin_icon_lookup], img[src*=btpesq_mdi], [style*=fwskin_icon_lookup], [style*=btpesq_mdi]")),None)
                 icon_s = self.soup_to_selenium(icon)
-                container = self.get_current_container()
                 self.click(icon_s)
-
-            container_end = self.get_current_container()
-            if (container.get('id') == container_end.get('id')):
+            else:
+                logger().debug("Sending F3 to input field")
                 input_field = lambda: self.driver.find_element(By.XPATH, xpath_soup(element))
                 self.set_element_focus(input_field())
                 self.send_keys(input_field(), Keys.F3)
 
-            while( time.time() < endtime and container.get('id') == container_end.get('id')):
-                container_end = self.get_current_container()
-                time.sleep(0.01)
+            logger().debug("Waiting for new container")
+            endtime_internal = time.time() + (self.config.time_out / 5)
 
-            if time.time() > endtime:
-                logger().debug("Timeout: new container not found.")
-            else:
-                logger().debug("Success")
+            while (time.time() < endtime_internal):
 
-        except Exception as e:
-            logger().exception(str(e))
+                container_id_after = self.get_current_container().get('id')
 
+                if container_id_after and container_id_before != container_id_after:
+                    success = True
+                    break
+
+                time.sleep(0.5)
+            
+            attempt += 1        
+
+        if success:
+            logger().debug(f"Success! New container opened after {attempt} attempt(s).")
+        else:
+            logger().debug(f"Failed! New container didn't open after {attempt} attempt(s).")
+
+        logger().debug(f"Container ID: before = {container_id_before} / after = {container_id_after}")
+        logger().info("Action F3 executed!")
 
     def SearchBrowse(self, term=None, key=None, identifier=None, index=False, column=None, filters=None):
         """

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -2029,33 +2029,29 @@ class WebappInternal(Base):
 
         return len(list(filter(lambda x: self.element_is_displayed(x), soup.select(term))))
 
-    def standard_search_field(self, term, name_attr=False,send_key=False):
+    def standard_search_field(self, term: str, name_attr: bool = False, send_key: bool = False) -> None:
         """
         [Internal]
 
-        Do the standard query(F3)
-        this method
-        1.Search the field
-        2.Search icon "lookup"
-        3.Click()
+        Internal implementation of the lookup (F3) action, called internally by the public F3 method.
 
-        :param term: The term that must be searched.
+        Locates the target field and retries, alternating between clicking the lookup icon and
+        sending the F3 key to the field, until a new container (the search/query modal) is detected
+        or the configured time_out is reached. Each attempt waits up to (self.config.time_out / 5)
+        seconds for the new container before switching strategy and trying again.
+
+        :param term: Label or internal name of the field to search.
         :type term: str
-        :param name_attr: If true searchs element by name.
+        :param name_attr: If True, searches the field by its name attribute instead of its label. - **Default:** False
         :type name_attr: bool
-        :param send_key: Try open standard search field send key F3 (no click).
+        :param send_key: If True, always opens the search window by sending the F3 key to the field, instead of clicking the lookup icon. - **Default:** False
         :type send_key: bool
 
-        Usage:
-
-        >>> # To search using a label name:
-        >>> self.standard_search_field(name_label)
-        >>> #------------------------------------------------------------------------
-        >>> # To search using the name of input:
-        >>> self.standard_search_field(field='A1_EST',name_attr=True)
-        >>> #------------------------------------------------------------------------
-        >>> # To search using the name of input and do action with a key:
-        >>> oHelper.F3(field='A1_EST',name_attr=True,send_key=True)
+        .. note::
+            If the field itself cannot be found on the screen, this method fails the test case
+            through log_error. If the field is found but the new container doesn't open within
+            time_out, the method does **not** fail the test case; it only logs the failure for
+            debugging purposes.
         """
 
         success = False
@@ -2087,9 +2083,12 @@ class WebappInternal(Base):
             
             if (not send_key and attempt % 2 == 0):
                 logger().debug("Clicking on search icon")
-                icon = next(iter(element.select("img[src*=fwskin_icon_lookup], img[src*=btpesq_mdi], [style*=fwskin_icon_lookup], [style*=btpesq_mdi]")),None)
-                icon_s = self.soup_to_selenium(icon)
-                self.click(icon_s)
+                icon = next(iter(element.select("img[src*=fwskin_icon_lookup], img[src*=btpesq_mdi], [style*=fwskin_icon_lookup], [style*=btpesq_mdi]")), None)
+                if icon is not None:
+                    icon_s = self.soup_to_selenium(icon)
+                    self.click(icon_s)
+                else:
+                    logger().debug("Search icon not found on this attempt")
             else:
                 logger().debug("Sending F3 to input field")
                 input_field = lambda: self.driver.find_element(By.XPATH, xpath_soup(element))


### PR DESCRIPTION
## 1. Contexto

O método `F3` (implementado internamente por `standard_search_field`) é usado no Protheus Webapp para abrir a tela de pesquisa (lookup) de um campo. Por exemplo, no campo "Cliente" o usuário aperta F3 ou clica no ícone de lupa, filtra o cliente na grid, seleciona e confirma — o valor é então preenchido no campo. Pode ter outras finalidades além do exemplo do campo "Cliente".

Foi identificado que, em alguns casos, o modal (container) contendo a grid de filtros não estava sendo aberto. O problema foi relatado na task `#CA-12063` (ryver), na rotina `JURA094` do ambiente 2510.

Ao investigar `standard_search_field`, notou-se que o método não seguia o padrão dos demais métodos do arquivo: fazia no máximo duas tentativas (clique ou `send_keys`, sem alternância) e desistia, sem lógica de retry até o sucesso ou até o timeout configurado.

## 2. O que foi alterado

**Arquivos:** `tir/main.py` e `tir/technologies/webapp_internal.py`

### 2.1 Lógica de retry no `standard_search_field`

O método foi refatorado mantendo a mesma ideia original, mas passou a alternar entre as duas estratégias de abertura até obter sucesso:

```
-> Acha o elemento
-> Tenta abrir o modal clicando no ícone
-> Aguarda por (self.config.time_out / 5) o container abrir
-> Se abrir, encerra o método
-> Se não abrir, tenta de novo
-> Na tentativa seguinte, tenta usando send_keys (F3) e repete o mesmo processo
-> Alterna entre as duas estratégias até atingir o timeout principal (self.config.time_out)
```

Quando `send_key=True` é passado pelo usuário, o método usa exclusivamente a estratégia de `send_keys`, sem alternar para o clique no ícone — mantendo a semântica original do parâmetro.

### 2.2 Remoção do suporte a ambiente legado (não-shadow-root)

O código antigo tinha um branch condicional para localizar o elemento de forma diferente quando `self.webapp_shadowroot()` era `False` (`.find_parent()` adicional). Esse suporte ao ambiente legado (não-shadow-root) foi **oficialmente descontinuado** para este método, então o branch foi removido. O método agora assume `webapp_shadowroot() == True`.

### 2.3 Log aprimorado

Foram adicionados logs (`logger().info` / `logger().debug`) em cada etapa (busca do campo, tentativa de abertura, resultado de cada tentativa, ID do container antes/depois) para facilitar o debug quando o F3 falhar.

### 2.4 Type hints

Adicionados type hints nos parâmetros e retorno de:
- `tir/main.py::F3(self, field: str, name_attr: bool = False, send_key: bool = False) -> None`
- `tir/technologies/webapp_internal.py::standard_search_field(self, term: str, name_attr: bool = False, send_key: bool = False) -> None`

Nenhuma assinatura pública foi alterada em termos de nomes, ordem, quantidade de parâmetros ou valores default — apenas tipagem foi adicionada. **Não há quebra de contrato para scripts já escritos por QAs.**

### 2.5 Docstrings atualizadas

- `main.py::F3`: docstring simplificada e orientada ao usuário final, explicando o conceito de lookup/F3 com exemplo de negócio, sem detalhes de implementação.
- `webapp_internal.py::standard_search_field`: docstring técnica, explicando o algoritmo de retry, o timeout parcial por tentativa (`time_out / 5`) e a condição de falha, referenciando que o método é a implementação interna chamada pelo `F3` público (sem repetir os exemplos de uso já documentados em `main.py`).

### 2.6 Proteção no clique do ícone de lookup

Adicionada verificação de `None` antes de converter o ícone encontrado via BeautifulSoup para elemento Selenium:

Isso evita que uma exceção não tratada interrompa o método quando o ícone não for encontrado em uma tentativa específica — o fluxo de retry simplesmente segue e, na tentativa seguinte, alterna para a estratégia de `send_keys(F3)`.

## 3. Impacto no fluxo anterior

| Cenário | Fluxo anterior | Fluxo novo |
|---|---|---|
| Campo do F3 não encontrado na tela | Exceção era capturada por um `try/except` global e apenas logada (`logger().exception`) — **o teste não falhava** | Chama `log_error`, que **falha o teste (CT)** de forma explícita e imediata |
| Modal/container não abre dentro do timeout | Não gerava erro, apenas log de debug ("Timeout: new container not found") | Continua **não gerando erro** — apenas loga debug de falha, mantendo o comportamento original |
| Estratégia de abertura (clique vs. `send_keys`) | Testava uma estratégia (definida por `send_key`) apenas uma vez, com no máximo uma segunda tentativa fixa via `send_keys` | Alterna entre clique no ícone e `send_keys(F3)` a cada tentativa, repetindo até o timeout total, exceto quando `send_key=True` (usa sempre `send_keys`) |
| Ambiente não-shadow-root (legado) | Suportado via `.find_parent()` condicional | **Não suportado.** Suporte descontinuado oficialmente; método assume `webapp_shadowroot() == True` |
| Ícone de lookup ausente no DOM no momento da tentativa | Risco de exceção não tratada ao converter `None` em elemento Selenium | Protegido: tentativa é ignorada com log de debug, sem interromper o método |

### ⚠️ Mudança de comportamento intencional

A mudança mais visível para scripts existentes é: **se o campo pesquisado pelo F3 não for encontrado na tela, o teste agora falha explicitamente** (antes, essa falha era engolida silenciosamente por um `try/except` genérico, e o script seguia executando como se nada tivesse acontecido).

Essa mudança é **intencional**: entende-se que engolir esse tipo de falha mascarava problemas reais e dificultava o diagnóstico (o erro só aparecia depois, em outro método, sem apontar que a causa raiz foi o F3). Já a falha em abrir o container (modal) dentro do timeout **continua não gerando erro**, mantendo o comportamento já esperado pelos scripts existentes para esse caso específico.

**Ação recomendada:** scripts que dependem de F3 em campos que hoje "passam" mesmo com o campo ausente da tela devem ser revisados após o merge, pois passarão a falhar corretamente.

## 4. Riscos e mitigação

| Risco | Mitigação |
|---|---|
| Scripts que hoje "passam" com campo do F3 ausente da tela começarão a falhar após o merge | Mudança documentada nesta descrição e no code (docstring com `.. note::`); recomenda-se comunicar a mudança aos QAs antes do rollout |
| Ambientes ainda em modo não-shadow-root podem ser afetados pela remoção do branch legado | Decisão de produto: suporte a não-shadow-root já foi descontinuado para este fluxo; não é uma regressão não intencional |
| Ícone de lookup não encontrado interrompendo o método | Mitigado nesta versão com verificação de `None` antes do clique |

## 6. Checklist de testes

- [x] Executar a rotina EICA080 (CT001) que contém 1 chamada `F3(field="...")`
- [X] Executar a rotina JURA094 que contém 2 chamadas `F3(field="...", name_attr=True)`
- [x] Executar a rotina FINA893 que contém 1 chamada `F3(field="...", send_key=True)`
- [x] Executar a rotina FISA160 (CT001 e 002 que contém 1 chamadaa `F3(field="...", name_attr=True, send_key=True)`

## 7. Pendências conhecidas

- Nenhuma pendência de código identificada nas revisões realizadas até o momento.
