### PR TITLE
fix(poui_internal): add fallback strategy for input field clearing

### DIFF
--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -6545,7 +6545,13 @@ class PouiInternal(Base):
                 self.scroll_to_element(input_field_element())
                 self.set_element_focus(input_field_element())
                 self.click(input_field_element())
-                input_field_element().clear()
+
+                try:
+                    input_field_element().clear()
+                except Exception as clear_error:
+                    logger().debug(f"clear() failed, falling back to select-all + delete: {clear_error}")
+                    ActionChains(self.driver).key_down(Keys.CONTROL).send_keys('a').key_up(Keys.CONTROL).send_keys(Keys.DELETE).perform()
+
                 input_field_element().send_keys(value)
                 ActionChains(self.driver).key_down(Keys.ENTER).perform()
                 ActionChains(self.driver).key_down(Keys.TAB).perform()


### PR DESCRIPTION
- Wrap input_field_element().clear() in try-except block to handle clearing failures
- Implement fallback mechanism using Ctrl+A + Delete key combination when clear() fails
- Add debug logging to track when fallback strategy is triggered
- Improve robustness of input field manipulation in wa-tab-view scenarios

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Hotfix - Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Manual
- [ ] SmartTest

**Test Configuration**:
* Add your description.
