### PR TITLE
Retry grid lookup without blocked filter

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -6856,9 +6856,13 @@ class WebappInternal(Base):
         success = None
         grids = None
         term = self.grid_selectors["new_web_app"]
+        try_containers_blocked = False
 
         endtime = time.time() + self.config.time_out
-        while(time.time() < endtime and not success):
+        while(not success):
+
+            if try_containers_blocked:
+                logger().debug("Looking for element without blocked-container filtering.")
 
             if not current_container:
                 grids = self.web_scrap(term= grid_element or term, scrap_type=enum.ScrapType.CSS_SELECTOR,
@@ -6878,6 +6882,18 @@ class WebappInternal(Base):
 
             if not wait:
                 break
+
+            if time.time() > endtime and not try_containers_blocked:
+                self.filter_blocked_containers = False
+                try_containers_blocked = True
+            
+            elif time.time() > endtime and try_containers_blocked:
+                break
+
+        if success and try_containers_blocked:
+            logger().debug("Element found without blocked-container filtering.")
+
+        self.filter_blocked_containers = True
 
         if success:
             return success

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -6829,7 +6829,7 @@ class WebappInternal(Base):
             success = td.text in text
 
     def get_grid(self, grid_number=0, grid_element = None, grid_list=False, wait=True, check_error=True, current_container=False):
-         """
+        """
         [Internal]
         Gets a grid BeautifulSoup object from the screen.
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -6829,22 +6829,30 @@ class WebappInternal(Base):
             success = td.text in text
 
     def get_grid(self, grid_number=0, grid_element = None, grid_list=False, wait=True, check_error=True, current_container=False):
-        """
+         """
         [Internal]
         Gets a grid BeautifulSoup object from the screen.
 
+        If the grid is not found within the configured time_out, this method performs one
+        additional attempt with `filter_blocked_containers` disabled, to handle cases where
+        a container is intermittently stuck in a "blocked" state and would otherwise never
+        be matched. The flag is always restored to True before returning.
+
         :param grid_number: The number of the grid on the screen.
-        :type: int
+        :type grid_number: int
         :param grid_element: Grid class name in HTML ex: ".tgrid".
-        :type: str
-        :return: Grid BeautifulSoup object
-        :rtype: BeautifulSoup object
+        :type grid_element: str
         :param grid_list: Return all grids.
         :type grid_list: bool
         :param wait: If False, doesn't wait/loop for the grid to appear, just checks once and returns whatever grids are found immediately.
         :type wait: bool
-        :param current_container: If it is false, it is queried by web_scrap. If it is true, it was selected from the current container.
-        :type wait: bool
+        :param check_error: If True, checks for error/warning screens while searching for the grid.
+        :type check_error: bool
+        :param current_container: If False, the grid is queried via web_scrap. If True, it is selected directly from the current container.
+        :type current_container: bool
+
+        :return: Grid BeautifulSoup object
+        :rtype: BeautifulSoup object
 
         Usage:
 
@@ -9475,6 +9483,8 @@ class WebappInternal(Base):
         >>> #Calling the method:
         >>> self.log_error("Element was not found")
         """
+
+        self.filter_blocked_containers = True
 
         if self.blocker:
             message += f' Blocker: {self.blocker}'


### PR DESCRIPTION
## 1. Contexto

Foi identificado na rotina **TMKA510A** (task #CA-12673) uma falha intermitente:

```
003 - [ClickGridCell] Couldn't find grid.
```

O log mostra que o problema não é a ausência da grid na tela, e sim que `web_scrap` não conseguiu localizar o container que a contém:

```
ERROR-...::webapp_internal::web_scrap|4205:: Web Scrap couldn't find container - term: .dict-tgetdados, .dict-tcbrowse, ...
```

A causa raiz apontada é que, em determinados cenários, um container pode ficar preso no estado `blocked` de forma intermitente e não retornar ao estado normal, fazendo com que o filtro de containers bloqueados (`filter_blocked_containers`) descarte o container correto indefinidamente até o timeout.

Esse comportamento já era tratado de forma pontual em outros métodos do arquivo (`get_field`, `wait_element`, `SetButton`), usando a mesma variável de controle global `filter_blocked_containers`. Este PR estende o mesmo tratamento, já validado em produção, para o método `get_grid`.

## 2. O que foi alterado

Arquivo único alterado: `tir/technologies/webapp_internal.py`.

**`get_grid`:**
- O laço de busca da grid deixou de sair automaticamente por timeout (`while(time.time() < endtime and not success)`) e passou a controlar o timeout dentro do próprio corpo do laço (`while(not success)`).
- Ao atingir o timeout sem sucesso, é feita **uma tentativa adicional** com `self.filter_blocked_containers = False`, buscando a grid ignorando o filtro de containers bloqueados.
- Se essa tentativa extra também falhar, o laço é interrompido (`break`), preservando o comportamento de erro final (`log_error("Couldn't find grid.")`).
- Ao final do método (com ou sem sucesso), `self.filter_blocked_containers` é sempre restaurado para `True`.
- Docstring do método corrigida e expandida: tipos de `grid_number`/`grid_element` que estavam genéricos (`:type: int` / `:type: str`) foram corrigidos para citar o parâmetro correto, documentação de `check_error` foi adicionada (estava faltando), e o novo comportamento de retry sem filtro foi documentado.

**`log_error`:**
- Adicionado `self.filter_blocked_containers = True` como primeira instrução do método.
- Mitiga o risco de vazamento de estado: como `get_grid`, `get_field`, `wait_element` e `SetButton` todos setam `filter_blocked_containers = False` durante o retry e só restauram para `True` ao final do método, uma exceção lançada no meio desse trecho (por exemplo, via `web_scrap` → `search_for_errors` → `log_error` → `assertTrue`) faria a flag "vazar" em `False` para o próximo caso de teste. Resetá-la no início de `log_error` — funil comum de todos esses pontos de falha — garante que o próximo CT sempre comece com o filtro no estado padrão.

## 3. Impacto no fluxo anterior

- **Fluxo anterior de `get_grid`:** buscava a grid repetidamente até o timeout; se não encontrasse, saía do laço e retornava erro (`log_error`).
- **Fluxo novo:** idêntico ao anterior no caminho feliz (grid encontrada dentro do timeout) e no caso `wait=False`. A única mudança de comportamento é a tentativa extra, sem filtro de containers bloqueados, executada uma única vez após o timeout e antes de declarar erro definitivo.
- **`log_error`:** nenhuma mudança de fluxo para quem já usava o método; apenas passou a resetar uma variável de controle interna antes de qualquer outra ação (não afeta mensagens de log, screenshots ou o `assertTrue` final).
- Não há remoção de bloco `webapp_shadowroot` nem impacto em caminhos condicionados a `self.config` neste PR.

## 4. Riscos e mitigação

| Risco | Mitigação |
|---|---|
| Estado global `filter_blocked_containers` vazar para o próximo CT em caso de exceção no meio do retry | Mitigado neste PR com o reset no início de `log_error`, funil comum de todos os métodos que usam esse padrão (`get_grid`, `get_field`, `wait_element`, `SetButton`) |
| Fallback sem efeito quando `current_container=True` | Confirmado pelo autor que `get_current_container()` também passa pelo filtro de containers bloqueados internamente — o fallback tem efeito nos dois caminhos (`current_container=True` e `False`) |

## 6. Checklist de testes

- [x] Suíte `TMKA510A` executada e sem a falha (A intermitência relatada só é possível ser analisada na execução da fila no SmartTest, ela não é reproduzida localmente)
- [ ] Teste de regressão em ao menos uma suíte adicional que utilize grids intensivamente
    - [x] FINA677
    - [x] MNTA420_02
    - [x] CTBA240
    - [x] JURA204B
- [ ] Confirmação de que `filter_blocked_containers` retorna a `True` após um cenário de erro forçado (via `log_error`)

## 7. Pendências conhecidas

- Não foi adicionado teste automatizado específico para o cenário de container bloqueado, já que o projeto não possui suíte unitária para `webapp_internal.py` (validação é feita via execução real/TIR). A validação depende da reexecução da rotina `TMKA510A` em ambiente real.
- O padrão de reset de `filter_blocked_containers` foi corrigido apenas no funil comum (`log_error`); não foi adicionado `try/finally` individual em `get_field`, `wait_element` e `SetButton`, o que é aceitável dado que `log_error` cobre esses casos, mas vale registrar como decisão consciente e não lacuna esquecida.
