### PR TITLE
Fix: propagate check_error param in SetButton's shadowroot fallback

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -4932,7 +4932,7 @@ class WebappInternal(Base):
 
         # Fallback: busca ampla via web_scrap
         if not filtered_buttons:
-            filtered_buttons = self.web_scrap(term=button, scrap_type=enum.ScrapType.MIXED, optional_term="wa-button", main_container=self.containers_selectors["SetButton"])
+            filtered_buttons = self.web_scrap(term=button, scrap_type=enum.ScrapType.MIXED, optional_term="wa-button", main_container=self.containers_selectors["SetButton"], check_error=check_error)
 
         if filtered_buttons and len(filtered_buttons) - 1 >= position:
             parents_actives = list(filter(lambda x: self.filter_active_tabs(x), filtered_buttons))


### PR DESCRIPTION
# Correção: propagação de `check_error` em `get_shadowroot_button` (fallback via `web_scrap`)

## Problema

No fluxo `CheckHelp` → `SetButton(button, check_error=False)` → `get_shadowroot_button(button, term_button, position, check_error)`, o parâmetro `check_error=False` não era propagado até o final da cadeia.

Dentro de `get_shadowroot_button`, no fallback "busca ampla via `web_scrap`" (usado quando nenhum botão candidato é encontrado pelos filtros anteriores), a chamada a `self.web_scrap(...)` não passava o parâmetro `check_error`. Como o valor default de `check_error` em `web_scrap` é `True`, essa chamada específica sempre executava `search_for_errors()`, ignorando a intenção do chamador de suprimir a checagem de erro.

Isso é particularmente problemático em `CheckHelp`, que chama `SetButton(button, check_error=False)` justamente porque a tela de Help é tecnicamente reconhecida como um "erro" pelo `search_for_errors()`. Sem a propagação correta, esse fallback podia disparar uma checagem de erro indevida nesse cenário.

## Correção

Adicionado `check_error=check_error` na chamada de `web_scrap` dentro do fallback de `get_shadowroot_button`:

```python
# Antes
filtered_buttons = self.web_scrap(term=button, scrap_type=enum.ScrapType.MIXED, optional_term="wa-button", main_container=self.containers_selectors["SetButton"])

# Depois
filtered_buttons = self.web_scrap(term=button, scrap_type=enum.ScrapType.MIXED, optional_term="wa-button", main_container=self.containers_selectors["SetButton"], check_error=check_error)
```

## Verificação adicional

Foi feita uma revisão completa de toda a cadeia de chamadas internas de `SetButton` (`get_shadowroot_button`, `recapture_setbutton_element`, `set_button_x`, `set_button_character`, `click_sub_menu`, `find_sub_menu_child`/`find_sub_menu_text`, `wait_element`, `wait_element_timeout`, `element_exists`, `grid_dataframe`, `get_grid`, `send_action`, `click`, `soup_to_selenium`, `set_element_focus`, `scroll_to_element`, `check_layers`, `element_is_displayed`, `element_is_on_top`) para confirmar que não havia outros pontos com o mesmo problema.

Não foram encontradas outras ocorrências. O único fallback que usa `check_error=False` fixo (dentro do próprio `SetButton`, na busca "sem filtro de blocked-container") é intencional — trata-se de uma tentativa de contingência silenciosa e não deve depender do parâmetro recebido pelo chamador.

## Impacto

- Nenhuma alteração de assinatura de método.
- Correção pontual, sem efeitos colaterais em outros fluxos que usam `SetButton` com `check_error=True` (comportamento padrão).
- Resolve falso positivo de erro em cenários de `CheckHelp` (e qualquer outro fluxo que chame `SetButton(..., check_error=False)` e caia nesse fallback específico).
