### PR TITLE
Fix infinite restart loop and coin screen timeout in POUI

### DIFF
--- a/tir/main.py
+++ b/tir/main.py
@@ -70,6 +70,9 @@ class Webapp():
         subscribe('webapp.check_news_screen', self.__webapp.check_news_screen)
         subscribe('webapp.close_screen_before_menu', self.__webapp.close_screen_before_menu)
 
+        subscribe('webapp.close_warning_screen', self.__webapp.close_warning_screen)
+        subscribe('webapp.close_coin_screen', self.__webapp.close_coin_screen)
+
     def AddParameter(self, parameter, branch, portuguese_value="", english_value="", spanish_value=""):
         """
         Adds a parameter to the queue of parameters to be set by SetParameters method.

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5700,7 +5700,8 @@ class PouiInternal(Base):
             logger().debug(f'Check Menu Screen: {success}')
 
         if not success:
-            self.log_error('Home screen not found!')
+            self.restart_counter += 1
+            self.log_error('Home screen not found!', restart_counter_param=self.restart_counter)
 
 
     def check_tmenu_screen(self):

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -897,6 +897,11 @@ class PouiInternal(Base):
         >>> # Calling the method:
         >>> self.close_coin_screen()
         """
+
+        from tir.technologies.core.events import emit
+        emit('webapp.close_coin_screen')
+        return
+
         soup = self.get_current_DOM()
         modals = self.zindex_sort(soup.select(".tmodaldialog"), True)
         if modals and self.element_exists(term=self.language.coins, scrap_type=enum.ScrapType.MIXED,
@@ -943,6 +948,11 @@ class PouiInternal(Base):
         >>> # Calling the method:
         >>> self.close_warning_screen()
         """
+
+        from tir.technologies.core.events import emit
+        emit('webapp.close_warning_screen')
+        return
+
         soup = self.get_current_DOM()
         modals = self.zindex_sort(soup.select(".ui-dialog"), True)
         if modals and self.element_exists(term=self.language.warning, scrap_type=enum.ScrapType.MIXED,

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -3888,12 +3888,7 @@ class WebappInternal(Base):
             self.user_screen()
             self.environment_screen()
 
-            twebview = True if self.config.new_home else False
-
-            endtime = time.time() + self.config.time_out
-            while(time.time() < endtime and not self.element_exists(term=".tmenu, .dict-tmenu, [class*='card-wrapper']", scrap_type=enum.ScrapType.CSS_SELECTOR, main_container="body", twebview=twebview)):
-                self.close_warning_screen()
-                self.close_modal()
+            self.close_screen_before_menu()
 
             if self.config.log_info_config:
                 self.set_log_info_config() 


### PR DESCRIPTION
## 1. Contexto

O ajuste surgiu da análise da rotina **PLSA974**, que estava apresentando timeout de execução. Foram identificados 3 erros relacionados, todos ligados à migração gradual das telas de WebApp para POUI:

1. O método `ChangeEnvironment` usa `close_coin_screen` para fechar a tela de moedas, porém a implementação nativa do POUI estava defasada e não fechava a tela com sucesso. Esse era o erro raiz: o erro não ocorria dentro do próprio método (ele era ignorado e o fluxo seguia), mas sim no `Program` chamado depois, que não conseguia acessar a rotina por estar bloqueado pela tela de moeda ainda aberta.
2. Esse erro causava um restart, mas dentro do `restart()` (não pelo método `Setup`), apenas as telas de warning e modal eram fechadas — a tela de moeda não era tratada, então ela permanecia aberta e a rotina continuava inacessível.
3. Como o método `Program` do POUI não incrementava o contador de restart (`restart_counter`) antes de registrar o erro, isso gerava um **loop infinito de restart**.

## 2. O que foi alterado

- **`tir/technologies/poui_internal.py`**
  - `close_coin_screen()` e `close_warning_screen()` passaram a delegar temporariamente a execução para a implementação do WebApp via event bus (`emit('webapp.close_coin_screen')` / `emit('webapp.close_warning_screen')`), já que a implementação nativa do POUI está defasada em relação à tela real exibida.
  - `escape_to_main_menu()`: ao não encontrar o menu principal, agora incrementa `self.restart_counter` antes de chamar `log_error(..., restart_counter_param=self.restart_counter)`, permitindo que o contador de tentativas seja propagado corretamente.

- **`tir/technologies/webapp_internal.py`**
  - `restart()`: o loop manual que esperava o menu aparecer e só chamava `close_warning_screen()` + `close_modal()` foi substituído pela chamada a `close_screen_before_menu()`, método já reutilizado em `Start()` e `TearDown()`, que fecha warning, moeda e modal antes de considerar o menu carregado.

- **`tir/main.py`**
  - Registro dos novos handlers no event bus: `subscribe('webapp.close_warning_screen', ...)` e `subscribe('webapp.close_coin_screen', ...)`, necessários para o desvio temporário do POUI para o WebApp funcionar.

## 3. Impacto no fluxo anterior

- **`escape_to_main_menu()` (POUI):** antes, uma falha ao localizar o menu chamava `log_error` sem contador de restart, permitindo tentativas ilimitadas. Agora o contador é incrementado e propagado, fazendo a execução ser encerrada corretamente após 3 tentativas (em vez de loopar).
- **`restart()` (WebApp):** antes fechava apenas warning e modal; agora fecha também a tela de moeda, reaproveitando `close_screen_before_menu()` e eliminando duplicação de código.
- **`close_coin_screen()` / `close_warning_screen()` (POUI):** o comportamento passa a usar os seletores e lógica do WebApp (via evento), e não mais a implementação nativa (defasada) do POUI. Essa é uma mudança de fluxo intencional e temporária.

## 4. Riscos e mitigação

- **Código morto temporário:** as implementações originais de `close_coin_screen()` e `close_warning_screen()` no POUI permanecem no arquivo, após o `return` antecipado, hoje inalcançáveis. Isso é aceito como parte do processo gradual de migração — a intenção final é unificar o `log_error` (e consequentemente essas telas auxiliares) entre WebApp e POUI, tornando esse desvio parte do plano definitivo de convergência.
- **Mistura de estado entre `PouiInternal` e `WebappInternal`:** o `restart_counter` incrementado no POUI é usado apenas para popular `restart_counter_param`, mas a decisão de interromper as tentativas (limite de 3) ocorre no `log_error` do WebApp. Isso é esperado dado que a unificação do `log_error` entre as duas tecnologias é o objetivo final da migração.
- **Cenário não-shadow-root do `restart()`:** ao reaproveitar `close_screen_before_menu()`, o seletor de espera do menu passou a ser `.dict-tmenu` (não mais `.tmenu`) quando `webapp_shadowroot() == False`. Mitigado pelo fato de `close_screen_before_menu()` já ser usado com sucesso em outros fluxos (`Start`, `TearDown`) nesse mesmo cenário.

## 5. Como validar (passo a passo)

1. Executar a rotina **PLSA974 - CT004** sem o ajuste do `ChangeEnvironment` (código anterior a este PR) e confirmar a reprodução do timeout/loop de restart.
2. Aplicar o ajuste deste PR e reexecutar a mesma rotina.
3. Confirmar que, ao reproduzir o cenário de falha (tela de moeda bloqueando o acesso à rotina), a execução:
   - Fecha a tela de moeda corretamente durante o `restart()`.
   - Encerra após 3 tentativas de restart (via `restart_counter`), em vez de loopar indefinidamente.

## 6. Checklist de testes

- [x] Reprodução do erro original na rotina PLSA974 (sem o ajuste do `ChangeEnvironment`).
- [x] Confirmação de que a execução finaliza após 3 tentativas de restart, em vez de loopar.

## 7. Pendências conhecidas

- As implementações antigas (código morto) de `close_coin_screen()` e `close_warning_screen()` no POUI devem ser removidas quando a unificação do `log_error` entre WebApp e POUI for concluída.
- Não há ticket/issue formal referenciado no PR para rastrear a remoção definitiva do desvio temporário; recomenda-se vincular esta tarefa a um ticket de acompanhamento da migração WebApp → POUI.
- Ausência de teste automatizado de regressão cobrindo o cenário de loop infinito de restart (mitigado por validação manual documentada acima).
