### PR TITLE
Fix combo selection regression via click-based fallback

### DIFF
--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -883,6 +883,10 @@ class Base(unittest.TestCase):
         :type shadow_root: bool
         :param locator: bool value for locator True or False
         :type locator: bool
+        :param by_click: If True, selects the option by clicking on the combobox and then on the
+            desired option, simulating a real user interaction instead of using Selenium's
+            select_by_index/select_by_visible_text. - **Default:** False
+        :type by_click: bool
 
         Usage:
 
@@ -912,28 +916,50 @@ class Base(unittest.TestCase):
             index_number = self.return_combo_index(combo, option)
             if index_number:
                 time.sleep(1)
-                if not by_click:
+                if not by_click or not self.click_combo_option(combo, combo.options[index_number]):
                     combo.select_by_index(str(index_number))
-                else:
-                    combo_options = list(filter(lambda x: not x.get_attribute('disabled'), combo.options))
-                    self.click(combo._el, click_type=enum.ClickType.SELENIUM)
-                    time.sleep(0.5)
-                    self.click(combo_options[index_number-1], click_type=enum.ClickType.SELENIUM)
         else:
             value = next(iter(filter(lambda x: x.text.lower().strip() == str(option).lower().strip() , combo.options)), None)
             if not value:
                 value = next(iter(filter(lambda x: x.text[0:len(str(option))].lower().strip()  == str(option).lower().strip() , combo.options)), None)
             if value:
                 time.sleep(1)
-                if not by_click:
-                    text_value = value.text
+                text_value = value.text
+                if not by_click or not self.click_combo_option(combo, value):
                     combo.select_by_visible_text(text_value)
-                else:
-                    self.click(combo._el, click_type=enum.ClickType.SELENIUM)
-                    time.sleep(0.5)
-                    self.click(value, click_type=enum.ClickType.SELENIUM)
                 logger().info(f"Selected value for combo is: {text_value}")
                 return text_value
+
+    def click_combo_option(self, combo, option_element):
+        """
+        [Internal]
+
+        Opens the combobox and clicks on the given option element, simulating a real user
+        interaction instead of using Selenium's select_by_index/select_by_visible_text.
+
+        Returns True if both clicks were performed successfully, False otherwise so callers
+        can fall back to the Selenium selection API.
+
+        :param combo: Selenium Select object
+        :type combo: selenium.webdriver.support.ui.Select
+        :param option_element: The option element to be clicked
+        :type option_element: Selenium WebElement
+        :return: True if the click sequence succeeded, False otherwise.
+        :rtype: bool
+        """
+        select_element = getattr(combo, "_el", None)
+
+        if select_element is None:
+            logger().warning("Could not resolve the select element for click-based selection, "
+                              "falling back to the default selection method")
+            return False
+
+        if not self.click(select_element, click_type=enum.ClickType.SELENIUM):
+            return False
+
+        time.sleep(0.5)
+
+        return self.click(option_element, click_type=enum.ClickType.SELENIUM)
 
     def return_combo_object(self, element, shadow_root=True, locator=False):
         """

--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -869,7 +869,7 @@ class Base(unittest.TestCase):
         if zindex_list:
             return next(iter(zindex_list), None)
 
-    def select_combo(self, element, option, index=False, shadow_root=True, locator=False):
+    def select_combo(self, element, option, index=False, shadow_root=True, locator=False, by_click: bool = False):
         """
         Selects the option on the combobox.
 
@@ -912,15 +912,26 @@ class Base(unittest.TestCase):
             index_number = self.return_combo_index(combo, option)
             if index_number:
                 time.sleep(1)
-                combo.select_by_index(str(index_number))
+                if not by_click:
+                    combo.select_by_index(str(index_number))
+                else:
+                    combo_options = list(filter(lambda x: not x.get_attribute('disabled'), combo.options))
+                    self.click(combo._el, click_type=enum.ClickType.SELENIUM)
+                    time.sleep(0.5)
+                    self.click(combo_options[index_number-1], click_type=enum.ClickType.SELENIUM)
         else:
             value = next(iter(filter(lambda x: x.text.lower().strip() == str(option).lower().strip() , combo.options)), None)
             if not value:
                 value = next(iter(filter(lambda x: x.text[0:len(str(option))].lower().strip()  == str(option).lower().strip() , combo.options)), None)
             if value:
                 time.sleep(1)
-                text_value = value.text
-                combo.select_by_visible_text(text_value)
+                if not by_click:
+                    text_value = value.text
+                    combo.select_by_visible_text(text_value)
+                else:
+                    self.click(combo._el, click_type=enum.ClickType.SELENIUM)
+                    time.sleep(0.5)
+                    self.click(value, click_type=enum.ClickType.SELENIUM)
                 logger().info(f"Selected value for combo is: {text_value}")
                 return text_value
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -3420,13 +3420,6 @@ class WebappInternal(Base):
                         else:
                             self.select_combo(element, main_value, by_click=True)
 
-                        try:
-                            self.set_element_focus(input_field())
-                            ActionChains(self.driver).send_keys(Keys.ENTER).perform()
-
-                        except Exception as e:
-                            logger().debug(f"An error occurred when pressing the Enter key in the select field: {e}")
-
                         current_value = self.return_selected_combo_value(element).strip()
                     #Action for Input elements
                     else:

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -3416,9 +3416,9 @@ class WebappInternal(Base):
                         main_element = element.parent
                         self.try_element_to_be_clickable(main_element)
                         if main_value == '':
-                           self.select_combo(element, main_value, index=True)
+                           self.select_combo(element, main_value, index=True, by_click=True)
                         else:
-                            self.select_combo(element, main_value)
+                            self.select_combo(element, main_value, by_click=True)
 
                         try:
                             self.set_element_focus(input_field())


### PR DESCRIPTION
## Contexto

O PR [#2093](https://github.com/totvs/tir/pull/2093) removeu a condição que restringia o disparo de `Enter` (via `ActionChains`) após a seleção de um combobox apenas ao navegador Chrome, passando a acionar essa tecla em todos os casos. Após a execução da fila de testes, foi identificado colateral nas rotinas **ATFA120**, **ATFA125**, **CNTA300**, **FINA460** e **OMSA341**: nessas rotinas existem campos do tipo select que não podem receber a ação de `Enter`, pois isso disparava uma tela de erro (help) informando que outros campos obrigatórios não haviam sido preenchidos.

## O que foi alterado

- Adicionado o parâmetro `by_click` (default `False`) ao método `select_combo` (`tir/technologies/core/base.py`), permitindo optar por uma seleção que simula uma interação humana real (abrir o combo e clicar na opção) em vez de usar as APIs `select_by_index` / `select_by_visible_text` do Selenium.
- Criado o novo método interno `click_combo_option` (`tir/technologies/core/base.py`), responsável por executar o clique de abertura do combo seguido do clique na opção desejada. Retorna `False` em qualquer falha, permitindo que `select_combo` caia automaticamente para o método tradicional do Selenium (fallback seguro).
- Em `tir/technologies/webapp_internal.py`, o fluxo de preenchimento de combobox dentro de `input_value` (usado por `SetValue`) passou a chamar `select_combo` com `by_click=True`.
- Removido o bloco que disparava `Keys.ENTER` via `ActionChains` após a seleção do combo nesse mesmo fluxo.

## Impacto no fluxo anterior

- **Fluxo antigo (pós-#2093):** seleciona valor no combo → foca elemento → dispara `Enter` sempre (com captura silenciosa de exceção em caso de falha).
- **Fluxo novo:** seleciona valor no combo → tenta abrir o select via clique real e clicar na opção → se falhar, cai para a seleção via API do Selenium (`select_by_index` / `select_by_visible_text`). Não há mais disparo de `Enter` nesse ponto.
- A mudança é intencional e resolve o bug relatado. Ela se aplica ao fluxo padrão de preenchimento de combobox usado por qualquer rotina que passe por `SetValue`, e não apenas às rotinas que apresentaram colateral — decisão consciente da equipe, já que não é prática do TIR restringir comportamento por rotina específica (apenas em últimos casos). A validação desse escopo mais amplo será feita na fila de testes antes de subir para a master.

## Riscos e mitigação

- **Escopo da mudança:** o novo comportamento (`by_click=True`) passa a valer para todos os campos combobox preenchidos via `SetValue`, não só para as rotinas com colateral. Mitigação: todas as rotinas serão testadas na fila de testes completa antes de subir para a master.
- **Estabilidade do clique em `<option>` nativo:** clique em opções de `<select>` nativo pode ter comportamento sensível ao navegador/driver, especialmente em modo headless. Mitigação: o método possui fallback automático para a seleção via Selenium em caso de falha no clique.
- **Dependência de atributo interno do Selenium (`_el`):** `click_combo_option` resolve o elemento subjacente ao objeto `Select` via `getattr(combo, "_el", None)`, um atributo não documentado como API pública do Selenium. Risco baixo/médio de quebra silenciosa em upgrades futuros da lib. Ver pendências conhecidas.

## Como validar (passo a passo)

1. Executar a fila de testes completa (todas as rotinas, não apenas as citadas no PR).
2. Confirmar que as rotinas com colateral original (ATFA120, ATFA125, CNTA300, FINA460, OMSA341) completam a seleção de combobox sem exibir a tela de erro de campos obrigatórios.
3. Confirmar que rotinas sem restrição (ex.: ATFA005) e rotinas que dependiam do `Enter` para submissão (ex.: FINA040 / CT154) continuam funcionando corretamente com a seleção por clique.
4. Validar visualmente (não-headless) que o clique de abertura do combo e o clique na opção realmente refletem a seleção esperada na interface.

## Checklist de testes

- [ ] Fila de testes completa executada (Chrome + Firefox, headless + não-headless)
- [ ] ATFA120, ATFA125, CNTA300, FINA460, OMSA341 sem colateral
- [ ] ATFA005 sem regressão
- [ ] FINA040 / CT154 sem regressão

## Pendências conhecidas

- Adicionar um comentário no código junto a `getattr(combo, "_el", None)` explicitando a dependência de atributo interno do Selenium, para facilitar manutenção futura em caso de upgrade de versão da lib.
- Considerar logar explicitamente quando o fallback (seleção via Selenium) é acionado após falha no clique, para facilitar diagnóstico de qual caminho está sendo usado em execuções de teste.
