### PR TITLE
Clear grid selection before removing browse filters

### DIFF
--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -6330,9 +6330,14 @@ class PouiInternal(Base):
 
         self._po_loading()
 
-        self._remove_filters_from_browse()
         if not self._is_po_button_inside_kendo_grid(self.language.filters):
             self._clear_table_selection(table_number=1, selection_type='all')
+
+        self._remove_filters_from_browse()
+
+        if not self._is_po_button_inside_kendo_grid(self.language.filters):
+            self._clear_table_selection(table_number=1, selection_type='all')
+
         self._clear_browse_input()
         self.wait_element(term=self.grid_selectors["grid_containers"], scrap_type=enum.ScrapType.CSS_SELECTOR)
 
@@ -6446,6 +6451,7 @@ class PouiInternal(Base):
 
         return success
 
+    @count_time
     def _is_po_button_inside_kendo_grid(self, button_text: str) -> bool:
         """
         [Internal]


### PR DESCRIPTION
## 1. Contexto

O PR tem como objetivo mitigar as falhas intermitentes `"SearchBrowse - Element 'Filtros' not found!"` observadas na fila da release 2610. O botão "Filtros" só é exibido quando nenhum item está selecionado no Browse. Em alguns cenários, a ação de "Remover Filtros" remove o filtro mas mantém o item selecionado, impedindo que o botão "Filtros" reapareça. Isso ocorre principalmente em fluxos onde: SearchBrowse → processo → retorno ao browse → novo SearchBrowse.

O autor não conseguiu reproduzir a falha em tempo de execução automatizado, apenas manualmente. A rotina usada como exemplo foi a CTBA010, mas o problema ocorre também em outras rotinas. A validação efetiva da correção depende da observação da próxima fila da release 2610.

## 2. O que foi alterado

Arquivo: `tir/technologies/poui_internal.py`

- Adicionada uma nova chamada de `_clear_table_selection(table_number=1, selection_type='all')` (protegida pela guarda `_is_po_button_inside_kendo_grid`) **antes** de `_remove_filters_from_browse()`, dentro do método `_set_browse_filters`. As duas chamadas equivalentes já existentes (após remover filtros e após limpar o input de busca) permanecem inalteradas.
- Adicionado o decorator `@count_time` ao método `_is_po_button_inside_kendo_grid`, para logging do tempo de execução (padrão já usado em `_clear_table_selection`).

## 3. Impacto no fluxo anterior

Nenhuma quebra de fluxo identificada. A alteração é puramente aditiva: insere um passo de limpeza de seleção antes do fluxo já existente, sem remover ou reordenar nenhuma etapa anterior.

## 4. Riscos e mitigação

- **Chamada redundante de `_po_loading()`**: `_clear_table_selection` invoca internamente `return_table()`, que chama `_po_loading()`. Como `_set_browse_filters` já chama `_po_loading()` imediatamente antes, há uma segunda espera por loading praticamente redundante. Impacto esperado é baixo (tempo extra pequeno), mas pode ser perceptível em grids grandes.
  - *Mitigação sugerida (não aplicada neste PR):* validar se o tempo adicional é aceitável em rotinas com grids grandes.
- **Correção não comprovada por reprodução automatizada**: o fix foi validado apenas manualmente. Não há garantia de que resolve o defeito relatado até a observação em fila real.
  - *Mitigação:* acompanhar explicitamente os resultados da próxima execução da fila da release 2610.
- **Duplicação de código**: o bloco de guarda (`_is_po_button_inside_kendo_grid` + `_clear_table_selection`) agora se repete 3 vezes dentro do mesmo método, aumentando o custo de manutenção e o número de percursos no DOM.
  - *Mitigação:* não aplicada neste PR (ver pendências conhecidas).

## 5. Como validar (passo a passo)

1. Acessar a rotina CTBA010 (ou outra rotina Browse afetada).
2. Executar um `SearchBrowse` com filtro.
3. Executar um processo qualquer sobre o registro filtrado (ex.: edição, visualização).
4. Retornar ao Browse.
5. Executar um novo `SearchBrowse`.
6. Confirmar que o botão "Filtros" está visível e funcional após o retorno, sem erro `"Element 'Filtros' not found!"`.
7. Repetir o ciclo (passos 2-6) múltiplas vezes para verificar a intermitência.

## 6. Checklist de testes

- [ ] Execução completa da fila de regressão na release 2610 (validação pendente, conforme relatado pelo autor).

## 7. Pendências conhecidas

- Confirmação da correção via observação da próxima fila da release 2610 (ainda não realizada no momento do review).
- Duplicação do bloco de guarda + limpeza de seleção (`_is_po_button_inside_kendo_grid` + `_clear_table_selection`), repetido 3 vezes em `_set_browse_filters`. Recomendável extrair para um método auxiliar único em revisão futura.
- Possível chamada redundante de `_po_loading()` no início de `_set_browse_filters`, decorrente da nova chamada de `_clear_table_selection` (que já invoca `_po_loading()` internamente via `return_table()`). Avaliar impacto de performance em grids grandes.
- Decorator `count_time` não utiliza `functools.wraps`, então funções decoradas perdem `__name__` original em introspecção (`_is_po_button_inside_kendo_grid` passa a aparecer como `wrapper`). Problema pré-existente no decorator, não introduzido por este PR, mas não corrigido.
