### PR TITLE
fix(poui_internal): add loading state after filling lookup input

### DIFF
--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -6576,8 +6576,8 @@ class PouiInternal(Base):
         :return: None
         """
         self._fill_input(input_element, value, field)
-
-        self._click_lookup_item(value)        
+        self._po_loading()
+        self._click_lookup_item(value)
 
     def _click_lookup_item(self, value):
         thf_item_list = self._get_lookup_list_item(value=value.strip().lower())


### PR DESCRIPTION
- Add loading state call before clicking lookup item to ensure UI synchronization
- Remove unnecessary blank line between fill_input and loading calls
- Improve lookup selection workflow by properly handling asynchronous loading behavior

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Hotfix - Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Manual
- [ ] SmartTest

**Test Configuration**:
* Add your description.
