### PR TITLE
fix(poui_internal, webapp_internal): move restart flags to shared con…

### DIFF
--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -5928,6 +5928,14 @@ class PouiInternal(Base):
         
         self.escape_to_main_menu()
 
+        # If restart() (WebappInternal) already handled this routine via emit, skip the rest.
+        # Flags live on self.config (shared singleton) since restart() runs on WebappInternal, not here.
+        if getattr(self.config, '_program_set_by_restart', False) or getattr(self.config, '_lateral_menu_set_by_restart', False):
+            self.config._program_set_by_restart = False
+            self.config._lateral_menu_set_by_restart = False
+            logger().debug(f"Program '{program_name or program_desc}' already set by restart, skipping.")
+            return
+
         logger().info(f"Setting program on the New Home: {program_name or program_desc}")
 
         success = False

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -1902,9 +1902,9 @@ class WebappInternal(Base):
             self.escape_to_main_menu()
 
             # If restart() already handled set_program via emit, skip the rest.
-            # The flag is consumed (reset) here so it only triggers once.
-            if getattr(self, '_program_set_by_restart', False):
-                self._program_set_by_restart = False
+            # Flag lives on self.config (shared singleton) since PouiInternal may set it.
+            if getattr(self.config, '_program_set_by_restart', False):
+                self.config._program_set_by_restart = False
                 logger().debug(f"Program '{program_name}' already set by restart, skipping.")
                 return
 
@@ -3896,12 +3896,13 @@ class WebappInternal(Base):
 
             if self.config.routine:
                 from tir.technologies.core.events import emit
+                # Flags stored on self.config (shared singleton) so PouiInternal can see them too.
                 if self.config.routine_type == 'SetLateralMenu':
                     emit('route.set_lateral_menu', self.config.routine, save_input=False)
-                    self._lateral_menu_set_by_restart = True
+                    self.config._lateral_menu_set_by_restart = True
                 elif self.config.routine_type == 'Program':
                     emit('route.set_program', self.config.routine)
-                    self._program_set_by_restart = True
+                    self.config._program_set_by_restart = True
 
     def wait_user_screen(self):
 
@@ -4641,9 +4642,9 @@ class WebappInternal(Base):
         self.escape_to_main_menu()
 
         # Se o restart() já navegou o menu lateral via emit, pula o restante.
-        # A flag é consumida (resetada) aqui para não interferir em chamadas futuras.
-        if getattr(self, '_lateral_menu_set_by_restart', False):
-            self._lateral_menu_set_by_restart = False
+        # Flag fica em self.config (singleton compartilhado), pois pode ter sido setada pelo PouiInternal.
+        if getattr(self.config, '_lateral_menu_set_by_restart', False):
+            self.config._lateral_menu_set_by_restart = False
             logger().debug(f"Lateral menu '{menu_itens}' already set by restart, skipping.")
             return
 
@@ -9589,8 +9590,8 @@ class WebappInternal(Base):
             self.restart_counter = 0
 
         if proceed_action() or not self.check_release_newlog():
-            self._program_set_by_restart = False
-            self._lateral_menu_set_by_restart = False
+            self.config._program_set_by_restart = False
+            self.config._lateral_menu_set_by_restart = False
             if self.restart_counter >= 3:
                 self.restart_counter = 0
             self.assertTrue(False, log_message)


### PR DESCRIPTION
pp# Fix: execução duplicada de `set_program`/`SetLateralMenu` no POUI (New Home) após `restart()`

## Contexto

O TIR está em processo de migração do WebApp legado para o **POUI (New Home)**. Durante essa migração, existem duas implementações paralelas (`WebappInternal` e `PouiInternal`), coordenadas por um `Router` e por um *event bus* simples (`tir.technologies.core.events`), que permite que uma emita eventos consumidos pela outra sem acoplamento direto.

O fluxo de recuperação de falhas (`restart()`) sempre roda na instância `WebappInternal`, mesmo quando o teste está configurado para `NewHome` (POUI). Quando o restart precisa reabrir a rotina que estava sendo testada, ele usa esse event bus (`emit('route.set_program', ...)` / `emit('route.set_lateral_menu', ...)`), que o `Router` traduz para uma chamada em `PouiInternal.set_program()` quando `config.new_home` está ativo.

## Problema

No `WebappInternal`, `set_program()` e `SetLateralMenu()` já tinham uma proteção contra reentrância: uma flag (`_program_set_by_restart` / `_lateral_menu_set_by_restart`) setada pelo `restart()` antes do `emit`, e checada logo no início desses métodos para pular a execução caso o `restart()` já tenha feito o trabalho.

Essa proteção **não existia em `PouiInternal.set_program()`**. Resultado observado em log real (`TIR_GTPA002TESTSUITE_...txt`, suite `GTPA002TestCase.py`):

1. `Program('GTPA002')` chama `set_program()` (POUI).
2. `escape_to_main_menu()` falha em encontrar a tela do menu → `log_error()` → `restart()` (WebApp).
3. `restart()` reabre a rotina via `emit('route.set_program', ...)`, que cai de novo em `PouiInternal.set_program()` (chamada aninhada) e conclui com sucesso.
4. Controle retorna para o `set_program()` externo (nível 1), que **não tinha guarda nenhuma** e continua a execução do zero, chamando `escape_to_main_menu()` novamente — agora procurando um elemento (`[class*='card-wrapper']`) que não existe mais, pois a aplicação já está dentro da rotina.
5. Isso gera um novo timeout, um novo `log_error()`, um novo `restart()` aninhado, repetindo o ciclo várias vezes.
6. A recursão resultante (`restart → set_program → log_error → restart → ...`) manteve o browser sendo recarregado por quase 1 hora, até o processo do WebDriver morrer (`InvalidSessionIdException`), abortando o `setUpClass` sem gerar um log de erro formal do TIR — só o traceback bruto do Selenium.

Um segundo desafio: mesmo replicando a mesma guarda usada no `WebappInternal`, ela não funcionaria da forma como estava (`getattr(self, '_program_set_by_restart', False)`), porque quem seta a flag (`WebappInternal.restart()`) e quem precisaria lê-la (`PouiInternal.set_program()`) são **instâncias Python diferentes**. Uma flag em `self` de uma não é visível no `self` da outra.

## Solução

- A flag passou a ser armazenada em `self.config` em vez de `self`. `ConfigLoader` é um singleton real do processo (`_instance` de classe em `__new__`), compartilhado entre `WebappInternal` e `PouiInternal` — ambos os `self.config` apontam para o mesmo objeto. Esse padrão de usar `self.config` como canal de estado transitório entre as duas implementações já existe no próprio TIR (`_flag_is_new_browse`, usado pelo `Router` entre `SearchBrowse`/`SetButton`), então a solução segue uma convenção já estabelecida no código, em vez de introduzir um padrão novo.
- Adicionada a guarda equivalente em `PouiInternal.set_program()`, verificando **ambas** as flags (`_program_set_by_restart` e `_lateral_menu_set_by_restart`), já que tanto `Program` quanto `SetLateralMenu` no New Home convergem para esse mesmo método.
- Ajustados os pontos correspondentes em `WebappInternal` (`restart()`, `set_program()`, `SetLateralMenu()`, `log_error()`) para ler/escrever a flag em `self.config`, mantendo a mesma lógica de set/consume/reset que já existia — só mudando onde o estado é guardado.

### Arquivos alterados

- `tir/technologies/webapp_internal.py`
  - `restart()`: seta as flags em `self.config` em vez de `self`.
  - `set_program()` / `SetLateralMenu()`: leem e resetam a flag em `self.config`.
  - `log_error()`: reset de segurança das flags também migrado para `self.config`.
- `tir/technologies/poui_internal.py`
  - `set_program()`: nova guarda no início do método, pulando a execução se `restart()` já tiver tratado a rotina.


## Teste realizado

- Compilação (`python -m py_compile`) de `webapp_internal.py` e `poui_internal.py` sem erros.
- Diagnóstico estático dos dois arquivos sem problemas.

## Como reproduzir o bug original (antes da correção)

Suite `GTPA002TestSuite.py` / `GTPA002TestCase.py`, forçando uma falha em `escape_to_main_menu()` durante o `Program('GTPA002')` do `setUpClass` (ex.: elemento de menu temporariamente indisponível). Sem a correção, o `restart()` aninhado deixa a execução externa de `set_program()` continuar do ponto errado, entrando em loop de `escape_to_main_menu()`/`restart()` até o WebDriver cair.
