### PR TITLE
Hotfix/click tree wait new layer

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -10531,7 +10531,11 @@ class WebappInternal(Base):
         # Split the treepath into label segments using '>' not preceded by '-'
         labels = list(map(str.strip, re.split(r'(?<!-)>', treepath)))
         labels = list(filter(None, labels))
-        dialog_layers = self.check_layers('wa-dialog')
+        initial_layers = self.check_layers('wa-dialog')
+        initial_container_id = self.get_current_container().get("id")
+        wait_new_layer = lambda: self.wait_element_timeout( term='wa-dialog', scrap_type=enum.ScrapType.CSS_SELECTOR,
+                                                            position=initial_layers + 1, timeout=10,
+                                                            presence=True, main_container='body', check_error=False)
 
         for row, label in enumerate(labels):
             logger().debug("Clicking on tree label: " + label)
@@ -10623,8 +10627,8 @@ class WebappInternal(Base):
                                             success = self.check_hierarchy(label_filtered, False) or is_element_acessible()
 
                                             # If dialog layers show up through last click
-                                            if not success and dialog_layers < self.check_layers('wa-dialog'):
-                                                success = True
+                                            if not success:
+                                                success = wait_new_layer() or self.get_current_container().get("id") != initial_container_id
 
                                             if success and right_click:
                                                 last_zindex = self.return_last_zindex()

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -10532,14 +10532,9 @@ class WebappInternal(Base):
         labels = list(map(str.strip, re.split(r'(?<!-)>', treepath)))
         labels = list(filter(None, labels))
         initial_layers = self.check_layers('wa-dialog')
-        container_endtime = time.time() + 10
-        initial_container_id = None
-        while ((time.time() < container_endtime) and not initial_container_id):
-            initial_container_id = self.get_current_container().get("id") if self.get_current_container() else None
         wait_new_layer = lambda: self.wait_element_timeout( term='wa-dialog', scrap_type=enum.ScrapType.CSS_SELECTOR,
                                                             position=initial_layers + 1, timeout=10,
                                                             presence=True, main_container='body', check_error=False)
-        check_container_changed = lambda: self.get_current_container().get("id") != initial_container_id if self.get_current_container() and initial_container_id else False
 
         for row, label in enumerate(labels):
             logger().debug("Clicking on tree label: " + label)
@@ -10633,7 +10628,7 @@ class WebappInternal(Base):
 
                                             # If dialog layers show up through last click
                                             if not success:
-                                                success = wait_new_layer() or check_container_changed()
+                                                success = wait_new_layer()
                                                 logger().debug(f'Result of success using layers / container id: {success}')
 
                                             if success and right_click:
@@ -10765,10 +10760,7 @@ class WebappInternal(Base):
         :rtype: list
         """
 
-        container_endtime = time.time() + 10
-        container = None
-        while ((time.time() < container_endtime) and not container):
-            container = self.get_current_container()
+        container = self.get_current_container()
 
         tr = []
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -10532,10 +10532,14 @@ class WebappInternal(Base):
         labels = list(map(str.strip, re.split(r'(?<!-)>', treepath)))
         labels = list(filter(None, labels))
         initial_layers = self.check_layers('wa-dialog')
-        initial_container_id = self.get_current_container().get("id")
+        container_endtime = time.time() + 10
+        initial_container_id = None
+        while ((time.time() < container_endtime) and not initial_container_id):
+            initial_container_id = self.get_current_container().get("id") if self.get_current_container() else None
         wait_new_layer = lambda: self.wait_element_timeout( term='wa-dialog', scrap_type=enum.ScrapType.CSS_SELECTOR,
                                                             position=initial_layers + 1, timeout=10,
                                                             presence=True, main_container='body', check_error=False)
+        check_container_changed = lambda: self.get_current_container().get("id") != initial_container_id if self.get_current_container() and initial_container_id else False
 
         for row, label in enumerate(labels):
             logger().debug("Clicking on tree label: " + label)
@@ -10623,12 +10627,14 @@ class WebappInternal(Base):
                                                     if click_type > 3:
                                                         click_type = 1
                                                 click_try += 1
-
+                                            
                                             success = self.check_hierarchy(label_filtered, False) or is_element_acessible()
+                                            logger().debug(f'Result of success using hierarchy / element acessible: {success}')
 
                                             # If dialog layers show up through last click
                                             if not success:
-                                                success = wait_new_layer() or self.get_current_container().get("id") != initial_container_id
+                                                success = wait_new_layer() or check_container_changed()
+                                                logger().debug(f'Result of success using layers / container id: {success}')
 
                                             if success and right_click:
                                                 last_zindex = self.return_last_zindex()
@@ -10659,10 +10665,11 @@ class WebappInternal(Base):
                                                 click_try += 1
                                             
                                             success = self.check_hierarchy(label_filtered)
+                                            logger().debug(f'Result of success using hierarchy: {success}')
 
                                         try_counter += 1
                                     except Exception as e:
-                                        pass
+                                        logger().debug(f"click_tree exception suppressed: {type(e).__name__}: {e}")
 
                                 if not success:
                                     try:
@@ -10758,12 +10765,17 @@ class WebappInternal(Base):
         :rtype: list
         """
 
-        container = self.get_current_container()
+        container_endtime = time.time() + 10
+        container = None
+        while ((time.time() < container_endtime) and not container):
+            container = self.get_current_container()
+
         tr = []
 
-        bs_tree_node = container.select('wa-tree')
-        if bs_tree_node and len(bs_tree_node) > tree_number:
-            tr = self.driver.execute_script(f"return arguments[0].shadowRoot.querySelectorAll('wa-tree-node')", self.soup_to_selenium(bs_tree_node[tree_number]))
+        if container:
+            bs_tree_node = container.select('wa-tree')
+            if bs_tree_node and len(bs_tree_node) > tree_number:
+                tr = self.driver.execute_script(f"return arguments[0].shadowRoot.querySelectorAll('wa-tree-node')", self.soup_to_selenium(bs_tree_node[tree_number]))
         return tr
 
     def check_hierarchy(self, label, check_expanded=True):


### PR DESCRIPTION
## Contexto

Foi relatado na task #CA-12748 do ryver que a rotina FISA001 estava apresentando falha **"APURACAO - [ClickTree] Element 'processar apuração da efd contribuições' not found!"** de forma intermitente.

Analisando o script da rotina, notei que era no primeiro comando da rotina que estava falhando (`self.oHelper.ClickTree('Apuração EFD Contribuições > Processar Apuração da EFD Contribuições')`).

Analisando o log, percebi que o clique na tree era feito com sucesso, mas por algum motivo ele tentava por uma segunda vez clicar na tree "Processar Apuração da EFD Contribuições" e acabava não encontrando ele, por isso do erro.

Importante: ao clicar nessa última tree, é aberto um novo modal "Parâmetros"

## Problema

Inicialmente eu achava que era por que o modal estava demorando para aparecer, então eu pensei em adicionar um tempo para aguardar o novo modal.

Porém depois eu consegui reproduzir exatamente o que acontece.

Acontece que depois do primeiro clique com selenium (linha ~10622), ao verificar se o elemento está acessível, é chamado o método "is_element_acessible" que através de métodos lambdas, chama o método treenode_selected, que chama o treenode, que executa container.select('wa-tree'), que por sua vez não tinha uma proteção caso não encontrasse o container.

E quando o modal estava sendo aberto, o get_current_container retornava none, gerando um erro. Porém esse erro era silenciado pelo try / except do método principal click tree e simplesmente voltava para o looping, tentando encontrar de novo a tree que já não estava disponível.

## Solução

Mantive a solução da suspeita inicial como proteção adicional e a solução do problema inicial.

Primeiro, eu melhorei a checagem de layers:

- Coloquei para aguardar até 10s por uma nova layer, caso não encontre verifica se o container mudou (processo já validado em outros métodos, como o do grid)
- No id do container inicial, eu coloquei um looping de 10s para aguardar o container, e caso não tenha, não é usado como checagem (controlado pelo método lambda check_container_changed)
- Aprimorei as mensagens de log para entender o que está acontecendo

Depois dessas alterações, ao testar em tempo de execução, eu consegui reproduzir o erro. Depois de adicionar mensagem de erro do try / except e rastrear o erro, consegui identificar que era a falta do container. Então eu adicionei:

- Tempo de 10s para aguardar o container, e se caso mesmo assim não encontre, não tenta selecionar.