### PR TITLE
feat(core): add clear_input method for robust input clearing

### DIFF
--- a/tir/technologies/core/base.py
+++ b/tir/technologies/core/base.py
@@ -990,6 +990,33 @@ class Base(unittest.TestCase):
         else:
             return ''
 
+    def clear_input(self, element):
+        """
+        [Internal]
+
+        Clears the content of an input element.
+
+        Selects the whole content with HOME + SHIFT + END and erases it with BACKSPACE,
+        avoiding the CTRL + A shortcut, that can be typed as a literal "a" in some inputs.
+
+        :param element: Selenium element
+        :type element: Selenium object
+
+        Usage:
+
+        >>> #Defining the element:
+        >>> element = lambda: self.driver.find_element(By.ID, "example_id")
+        >>> #Calling the method:
+        >>> self.clear_input(element())
+        """
+        try:
+            element.send_keys(Keys.HOME)
+            ActionChains(self.driver).key_down(Keys.SHIFT).send_keys(Keys.END).key_up(Keys.SHIFT).perform()
+            element.send_keys(Keys.BACK_SPACE)
+        except Exception:
+            ActionChains(self.driver).send_keys(Keys.HOME).key_down(Keys.SHIFT).send_keys(Keys.END) \
+                .key_up(Keys.SHIFT).send_keys(Keys.BACK_SPACE).perform()
+
     def send_keys(self, element, arg):
         """
         [Internal]
@@ -1015,11 +1042,10 @@ class Base(unittest.TestCase):
                 element.send_keys(Keys.CONTROL, 'a')
             element.send_keys(arg)
         except Exception:
-            actions = ActionChains(self.driver)
-            actions.move_to_element(element)
-            actions.click()
+            ActionChains(self.driver).move_to_element(element).click().perform()
             if arg.isprintable():
-                actions.key_down(Keys.CONTROL).send_keys('a').key_up(Keys.CONTROL).send_keys(Keys.DELETE)
+                self.clear_input(element)
+            actions = ActionChains(self.driver)
             actions.send_keys(Keys.HOME)
             actions.send_keys(arg)
             actions.perform()


### PR DESCRIPTION
- Add new clear_input() method to Base class for reliably clearing input element content
- Use HOME + SHIFT + END keyboard sequence instead of CTRL + A to avoid literal character input in some fields
- Include fallback exception handling using ActionChains for edge cases
- Refactor send_keys() exception handler to use clear_input() method
- Simplify ActionChains usage in send_keys() exception path with method chaining
- Improves input handling reliability across different input element types
MATA410 - MEX

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Hotfix - Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Manual
- [ ] SmartTest

**Test Configuration**:
* Add your description.
