### PR TITLE
Hotfix/find filter element match

### DIFF
--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -6708,6 +6708,7 @@ class PouiInternal(Base):
             return None, None
 
         partial_match = None
+        partial_match_label = ''
 
         for component_type in SUPPORTED_COMPONENTS:
             for component in filter_container.select(component_type):
@@ -6720,14 +6721,17 @@ class PouiInternal(Base):
                 if label_text == field_label_normalized:
                     input_el = component.select_one('input, select')
                     if input_el:
+                        logger().debug(f"Field '{field_label}' found by exact match on component '{component_type}' (label: '{label_text}').")
                         return component_type, input_el
 
                 elif partial_match is None and field_label_normalized in label_text:
                     input_el = component.select_one('input, select')
                     if input_el:
                         partial_match = (component_type, input_el)
+                        partial_match_label = label_text
 
         if partial_match:
+            logger().debug(f"Field '{field_label}' found by partial match on component '{partial_match[0]}' (label: '{partial_match_label}').")
             return partial_match
 
         logger().warning(f"Field '{field_label}' not found in any supported component type.")

--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -6707,13 +6707,28 @@ class PouiInternal(Base):
             logger().warning("Filter panel (po-page-slide) not found in DOM.")
             return None, None
 
+        partial_match = None
+
         for component_type in SUPPORTED_COMPONENTS:
             for component in filter_container.select(component_type):
                 label_el = component.select_one('label, span, .po-field-container-bottom-text')
-                if label_el and field_label_normalized in label_el.text.strip().lower():
+                if not label_el:
+                    continue
+
+                label_text = label_el.text.strip().lower()
+
+                if label_text == field_label_normalized:
                     input_el = component.select_one('input, select')
                     if input_el:
                         return component_type, input_el
+
+                elif partial_match is None and field_label_normalized in label_text:
+                    input_el = component.select_one('input, select')
+                    if input_el:
+                        partial_match = (component_type, input_el)
+
+        if partial_match:
+            return partial_match
 
         logger().warning(f"Field '{field_label}' not found in any supported component type.")
         return None, None


### PR DESCRIPTION
## Contexto

O método `_identify_filter_field` (`tir/technologies/poui_internal.py`) é utilizado no fluxo de aplicação de filtros do **Novo Browse** (THF/PO-UI). Ele localiza o input correspondente ao rótulo do parâmetro informado e retorna o elemento junto com o seu tipo, permitindo que o preenchimento seja feito de acordo com o componente encontrado (`po-input`, `po-datepicker`, `po-select` ou `thf-lookup`).

## Problema

Foi relatado na task #CA-12881 (Ryver) que a rotina **FINA340** passou a falhar em todos os CTs com a mensagem `[SearchBrowse] Couldn't find radio input element`.

Ao reproduzir o erro localmente, identificou-se que o método, antes do ajuste, buscava os elementos usando correspondência por **"contém"** e avaliava primeiro os componentes do tipo `po-input`, retornando imediatamente o primeiro encontrado. Na FINA340, existia um campo `po-input` com o rótulo "Tipo Fatura - Tipo da Fatura", que era retornado indevidamente no lugar do campo correto ("Tipo - Tipo do Título", do tipo `thf-lookup`), fazendo com que o preenchimento ocorresse no campo errado e a busca não retornasse registros.

## Solução

O método agora prioriza a **correspondência exata** do rótulo em todos os tipos de campo suportados (`po-input`, `po-datepicker`, `po-select`, `thf-lookup`), independentemente da ordem em que são verificados. Apenas quando nenhuma correspondência exata é encontrada em nenhum componente, é retornada a primeira correspondência parcial (comportamento anterior, mantido como fallback).

Foram adicionados logs de debug indicando se o elemento foi localizado por correspondência exata ou parcial, e qual componente/rótulo foi utilizado, facilitando o diagnóstico de casos semelhantes no futuro.

## Atenção

- **Scripts que dependiam do fallback parcial "por ordem"**: se algum script de QA passava um rótulo parcial contando com o comportamento antigo (primeiro match parcial na ordem de verificação), ele estava usando o parâmetro de forma incorreta. O correto é sempre informar o texto completo do label. É esperado e aceitável que esses scripts passem a falhar após esta correção.
- **Chave de filtro que não é o texto completo do label**: scripts que usam uma chave que não corresponde exatamente a nenhum label já estavam sujeitos ao mesmo problema antes desta correção (risco pré-existente, não introduzido por este PR).
- **Labels duplicados entre componentes**: não é esperado que dois campos do filtro tenham exatamente o mesmo label. Caso isso ocorra, é considerado erro de produto (dicionário/tela), não uma limitação do TIR.

## Testes realizados

Testes executados manualmente na release 2610 (única com o Novo Browse disponível):

- [x] Execução local da rotina **FINA340** (rotina que apresentava o erro original).
- [x] Execução local da rotina **MATA908** (rotina que já funcionava corretamente antes do ajuste, usada para validar que não houve regressão).

Não há evidência de testes automatizados (AdvPR/TIR) cobrindo o cenário de regressão.
