### PR TITLE
fix(webapp_internal): add periodic screen reload during user element …

### DIFF
--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -608,22 +608,8 @@ class WebappInternal(Base):
         try_counter = 0
         user_value = ''
         user_element = None
-        reload_screen_interval = self.config.time_out / 3
         endtime = time.time() + self.config.time_out
-        next_reload_time = time.time() + reload_screen_interval
-
         while (time.time() < endtime and (user_value.strip() != user_text.strip())):
-
-            if time.time() >= next_reload_time:
-                logger().debug("User element not found, reloading user screen...")
-
-                self.reload_user_screen()
-
-                next_reload_time = time.time() + reload_screen_interval
-                user_element = None
-                user_value = ''
-                try_counter = 0
-                continue
 
             logger().debug("Looking for user element...")
 

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -782,10 +782,11 @@ class WebappInternal(Base):
             self.driver_get(url=f"{self.config.url}/?StartProg=CASIGAADV&A={self.config.initial_program}&Env={self.config.environment}")
 
         if not self.config.skip_environment and not self.config.coverage:
-            self.program_screen(self.config.initial_program, environment=server_environment)
+            self.program_screen(self.config.initial_program, environment=server_environment, poui=self.config.poui_login)
 
-        self.wait_element_timeout(term="[name='cGetUser']",
-         scrap_type=enum.ScrapType.CSS_SELECTOR, timeout = self.config.time_out , main_container='body')
+        self.wait_element_timeout(term="[name='cGetUser'], .po-page-login-info-field .po-input",
+         scrap_type=enum.ScrapType.CSS_SELECTOR, timeout = self.config.time_out , main_container='body',
+         twebview = True if self.config.poui_login else False)
 
 
     def close_ballon_last_login(self):

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -608,8 +608,22 @@ class WebappInternal(Base):
         try_counter = 0
         user_value = ''
         user_element = None
+        reload_screen_interval = 120  # 2 minutes
         endtime = time.time() + self.config.time_out
+        next_reload_time = time.time() + reload_screen_interval
+
         while (time.time() < endtime and (user_value.strip() != user_text.strip())):
+
+            if time.time() >= next_reload_time:
+                logger().debug("User element not found, reloading user screen...")
+
+                self.reload_user_screen()
+
+                next_reload_time = time.time() + reload_screen_interval
+                user_element = None
+                user_value = ''
+                try_counter = 0
+                continue
 
             logger().debug("Looking for user element...")
 
@@ -625,7 +639,7 @@ class WebappInternal(Base):
                     user_element = next(iter(soup.select(get_user)), None)
 
                 if user_element is None:
-                    time.sleep(0.5)
+                    time.sleep(1)
                     continue
 
             except AttributeError as e:

--- a/tir/technologies/webapp_internal.py
+++ b/tir/technologies/webapp_internal.py
@@ -608,7 +608,7 @@ class WebappInternal(Base):
         try_counter = 0
         user_value = ''
         user_element = None
-        reload_screen_interval = 120  # 2 minutes
+        reload_screen_interval = self.config.time_out / 3
         endtime = time.time() + self.config.time_out
         next_reload_time = time.time() + reload_screen_interval
 


### PR DESCRIPTION
## Contexto

O método `user_screen` é responsável por localizar e preencher o campo de usuário na tela de login do Protheus Webapp, aguardando até `time_out` pelo elemento `user_element` ficar disponível e com o valor esperado preenchido.

## Problema

Em alguns cenários o `user_element` não é encontrado e o método fica preso tentando repetidamente até esgotar o timeout, exibindo apenas a mensagem "Looking for user element..." em loop. Ao final, a execução falha com "Couldn't fill User input element.", mesmo no print da falha ter a tela com o input do usuário.

## Solução

Adicionada uma tratativa dentro do próprio timeout do `user_screen`: a cada time_out / 3 (120 segundos) sem sucesso em localizar/preencher o `user_element`, o método `reload_user_screen()` é chamado automaticamente, retornando às telas de programa inicial/ambiente e voltando para a tela de usuário para uma nova tentativa. O controle de tempo desse retry está contido dentro do timeout principal do método, não adicionando tempo extra de espera. Um log de debug foi incluído para indicar quando o reload é executado.

## Testes

_(a preencher)_
