### PR TITLE
Revert "Hotfix/find filter element match" (#2119)

### DIFF
--- a/tir/technologies/poui_internal.py
+++ b/tir/technologies/poui_internal.py
@@ -6707,32 +6707,13 @@ class PouiInternal(Base):
             logger().warning("Filter panel (po-page-slide) not found in DOM.")
             return None, None
 
-        partial_match = None
-        partial_match_label = ''
-
         for component_type in SUPPORTED_COMPONENTS:
             for component in filter_container.select(component_type):
                 label_el = component.select_one('label, span, .po-field-container-bottom-text')
-                if not label_el:
-                    continue
-
-                label_text = label_el.text.strip().lower()
-
-                if label_text == field_label_normalized:
+                if label_el and field_label_normalized in label_el.text.strip().lower():
                     input_el = component.select_one('input, select')
                     if input_el:
-                        logger().debug(f"Field '{field_label}' found by exact match on component '{component_type}' (label: '{label_text}').")
                         return component_type, input_el
-
-                elif partial_match is None and field_label_normalized in label_text:
-                    input_el = component.select_one('input, select')
-                    if input_el:
-                        partial_match = (component_type, input_el)
-                        partial_match_label = label_text
-
-        if partial_match:
-            logger().debug(f"Field '{field_label}' found by partial match on component '{partial_match[0]}' (label: '{partial_match_label}').")
-            return partial_match
 
         logger().warning(f"Field '{field_label}' not found in any supported component type.")
         return None, None


### PR DESCRIPTION
# Description

Reverte o PR #2119 ("Hotfix/find filter element match"), que foi mergeado em `develop` de forma indevida.

O PR #2119 alterava o método `_identify_filter_field` (`tir/technologies/poui_internal.py`) para priorizar correspondência **exata** do rótulo do campo em todos os componentes suportados (`po-input`, `po-datepicker`, `po-select`, `thf-lookup`), usando a correspondência parcial apenas como fallback.

Este PR restaura o comportamento anterior: busca por "contém" (`in`), retornando o primeiro componente correspondente na ordem de verificação de `SUPPORTED_COMPONENTS`.

Detalhes:
- Merge revertido: `7665305db9c27e5752974d40eb243479c1b4b557`
- Commit de revert: gerado com `git revert -m 1`
- Resultado: a árvore de `tir/technologies/poui_internal.py` volta a ser idêntica à do commit anterior ao merge (`18b339d9`)

Reverts #2119

## Type of change

- [x] Hotfix - Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual

**Test Configuration**:
* Revert gerado automaticamente por `git revert -m 1`, sem conflitos.
* Verificado que o diff entre `18b339d9` (commit anterior ao merge do #2119) e o HEAD deste branch é vazio, ou seja, o arquivo retornou exatamente ao estado anterior.
* Validada a sintaxe do módulo `tir/technologies/poui_internal.py`.
* Observação: o cenário original relatado na task CA-12881 (FINA340) voltará a apresentar o comportamento anterior à correção do #2119.
